### PR TITLE
Fix the daymail image bug.

### DIFF
--- a/src/Etu/Module/UploadBundle/Resources/views/Main/index.html.twig
+++ b/src/Etu/Module/UploadBundle/Resources/views/Main/index.html.twig
@@ -49,7 +49,7 @@
                     </a>
                 </div>
                 <div class="upload-label">
-                    <input type="text" value="http://{{ etu.domain ~ asset('uploads/users_files/' ~ app.user.login ~ '/' ~ image.name) }}" />
+                    <input type="text" value="http://{{ etu.domain ~ 'uploads/users_files/' ~ app.user.login ~ '/' ~ image.name }}" />
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
Since the asset() function is adding "?v*.*.*" at the end of the resource link, the daymail script can't fetch the picture while parsing the body to find them. It occurs when the user copy/paste the image URL to insert it into a daymail.

Instead of patching the DaymailModule, I prefer to correct the display, since the version is not really useful in emails.