### PR TITLE
Fixes bbcode plugin not being loaded

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -262,6 +262,7 @@
             'vendor/bootstrap/docs/assets/js/bootstrap.min.js'
             'vendor/facebox/src/facebox.js'
             'vendor/SCEditor/src/jquery.sceditor.js'
+            'vendor/SCEditor/src/plugins/bbcode.js'
             'vendor/SCEditor/languages/fr.js'
             'vendor/tipsy/src/javascripts/jquery.tipsy.js'
             'vendor/jquery-ui-touch-punch/jquery.ui.touch-punch.min.js'


### PR DESCRIPTION
As of 1.4.1, sceditor doesn’t include the bbcode plugin anymore.

So do we need to include it ourselves. Meh.

/!\ This commit doesn’t fix screwed up posts. /!\

(PR open to discuss the issue, as none was created)