### PR TITLE
🆒 Fixes #3 - Badges without user

### DIFF
--- a/src/Etu/Core/UserBundle/Model/BadgesManager.php
+++ b/src/Etu/Core/UserBundle/Model/BadgesManager.php
@@ -218,8 +218,8 @@ class BadgesManager
 		$usersBadges = self::$doctrine->getRepository('EtuUserBundle:UserBadge')
 			->createQueryBuilder('ub')
 			->select('ub, u, b')
-			->leftJoin('ub.user', 'u')
-			->leftJoin('ub.badge', 'b')
+			->join('ub.badge', 'b')
+			->join('ub.user', 'u')
 			->getQuery()
 			->getResult();
 


### PR DESCRIPTION
Use intersection (=inner join) instead of union to retrieve
badges/users.
-> Will use less memory in 100 years \o/

Inner join: http://j.ungeek.fr/6272f (without NULL values)
Left join: http://j.ungeek.fr/bc621 (with NULL values)