### PR TITLE
Fixes #16 - Conventional OAuth2 Response

### DIFF
--- a/src/Etu/Core/ApiBundle/Controller/SecurityController.php
+++ b/src/Etu/Core/ApiBundle/Controller/SecurityController.php
@@ -226,7 +226,7 @@ class SecurityController extends ApiController
 
                 $em->flush();
 
-                return $this->redirect($client->getRedirectUri() . '?authorization_code=' . $authorizationCode->getCode());
+                return $this->redirect($client->getRedirectUri() . '?authorization_code=' . $authorizationCode->getCode() . '&code=' . $authorizationCode->getCode());
             } else {
                 return $this->redirect($client->getRedirectUri() . '?error=authentification_canceled&error_message=L\'utilisateur a annulé l\'authentification.');
             }
@@ -279,6 +279,18 @@ class SecurityController extends ApiController
      *          "required" = false,
      *          "dataType" = "string",
      *          "description" = "The refresh_token provided on the first access_token retrieval. Required if grant_type == 'refresh_token'."
+     *      },
+     *      {
+     *          "name" = "client_id",
+     *          "required" = false,
+     *          "dataType" = "string",
+     *          "description" = "Your Client ID (given in your developper panel). Required if not using Basic Authentification."
+     *      },
+     *      {
+     *          "name" = "client_secret",
+     *          "required" = false,
+     *          "dataType" = "string",
+     *          "description" = "Your Client Secret Token (given in your developper panel). Required if not using Basic Authentification."
      *      }
      *   }
      * )
@@ -291,8 +303,8 @@ class SecurityController extends ApiController
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
 
-        $clientId = $request->server->get('PHP_AUTH_USER');
-        $clientSecret = $request->server->get('PHP_AUTH_PW');
+        $clientId = $request->get('client_id', $request->server->get('PHP_AUTH_USER'));
+        $clientSecret = $request->get('client_secret', $request->server->get('PHP_AUTH_PW'));
 
         /** @var OauthClient $client */
         $client = $em->getRepository('EtuCoreApiBundle:OauthClient')->findOneBy([

--- a/src/Etu/Core/ApiBundle/Formatter/DataFormatter.php
+++ b/src/Etu/Core/ApiBundle/Formatter/DataFormatter.php
@@ -29,13 +29,14 @@ class DataFormatter
      */
     public function format($request, $data = array(), $status = 200, $message = null)
     {
-        $data = [
-            'http' => [
+        $data = array_merge($data, [
+            'http' => [ // @TODO: remove this when everything is OAuth2 compatible
                 'status' => $status,
-                'message' => ($message) ? $message : Response::$statusTexts[$status]
+                'message' => ($message) ? $message : Response::$statusTexts[$status],
+                '_note' => 'http and response fields are deprecated'
             ],
             'response' => $data
-        ];
+        ]);
 
         $format = 'json';
 

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/AuthorizationCodeGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/AuthorizationCodeGrantType.php
@@ -39,7 +39,7 @@ class AuthorizationCodeGrantType implements GrantTypeInterface
 
         /** @var OauthAuthorizationCode $authorizationCode */
         $authorizationCode = $this->manager->getRepository('EtuCoreApiBundle:OauthAuthorizationCode')
-            ->findOneBy([ 'code' => $request->request->get('authorization_code') ]);
+            ->findOneBy([ 'code' => $request->request->get('code', $request->request->get('authorization_code')) ]);
 
         if (! $authorizationCode) {
             throw new \RuntimeException('Authorization code not found');
@@ -91,6 +91,7 @@ class AuthorizationCodeGrantType implements GrantTypeInterface
         return [
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
+            'expires' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
             'refresh_token' => $token->getRefreshToken()->getToken(),
             'token_type' => 'Bearer'

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/AuthorizationCodeGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/AuthorizationCodeGrantType.php
@@ -92,7 +92,8 @@ class AuthorizationCodeGrantType implements GrantTypeInterface
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
-            'refresh_token' => $token->getRefreshToken()->getToken()
+            'refresh_token' => $token->getRefreshToken()->getToken(),
+            'token_type' => 'Bearer'
         ];
     }
 

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/ClientCredentialsGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/ClientCredentialsGrantType.php
@@ -66,6 +66,7 @@ class ClientCredentialsGrantType implements GrantTypeInterface
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
+            'token_type' => 'Bearer'
         ];
     }
 

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/ClientCredentialsGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/ClientCredentialsGrantType.php
@@ -65,6 +65,7 @@ class ClientCredentialsGrantType implements GrantTypeInterface
         return [
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
+            'expires' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
             'token_type' => 'Bearer'
         ];

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/RefreshTokenGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/RefreshTokenGrantType.php
@@ -81,6 +81,7 @@ class RefreshTokenGrantType implements GrantTypeInterface
         return [
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
+            'expires' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
             'refresh_token' => $token->getRefreshToken()->getToken(),
             'token_type' => 'Bearer'

--- a/src/Etu/Core/ApiBundle/Oauth/GrantType/RefreshTokenGrantType.php
+++ b/src/Etu/Core/ApiBundle/Oauth/GrantType/RefreshTokenGrantType.php
@@ -82,7 +82,8 @@ class RefreshTokenGrantType implements GrantTypeInterface
             'access_token' => $token->getToken(),
             'expires_at' => $token->getExpireAt()->format('U'),
             'scopes' => $scopes,
-            'refresh_token' => $token->getRefreshToken()->getToken()
+            'refresh_token' => $token->getRefreshToken()->getToken(),
+            'token_type' => 'Bearer'
         ];
     }
 


### PR DESCRIPTION
This patch makes the etu.utt.fr website OAuth2 compatible without
introducing breaking changes (unless you play with the raw data, count
keys or loop on them … But you shouldn’t) for former users.

There is no way to comment/deprecate things using json, and that’s
quite sad, don’t you think ? We’ll stick with a _note for now.

*Not merging now, please review this ... If you have any idea/suggestion/remark, say it now or forever hold your peace*

:fearful: 