### PR TITLE
Fix timezone in ics export

### DIFF
--- a/src/Etu/Core/UserBundle/Controller/ScheduleController.php
+++ b/src/Etu/Core/UserBundle/Controller/ScheduleController.php
@@ -141,7 +141,7 @@ class ScheduleController extends Controller
 				$day = $course->getDay();
 			}
 
-			$day = new \DateTime('last '.$day);
+			$day = new \DateTime('last '.$day, new \DateTimeZone('Europe/Paris'));
 
 			$start = clone $day;
 			$time = explode(':', $course->getStart());


### PR DESCRIPTION
Currently the timezone in the ICS export is UTC, but courses time are in the Paris timezone. This should fix it.