### PR TITLE
Responsive daymail

### DIFF
--- a/src/Etu/Module/DaymailBundle/BodyParser/BodyParser.php
+++ b/src/Etu/Module/DaymailBundle/BodyParser/BodyParser.php
@@ -21,19 +21,50 @@ class BodyParser
     }
 
     /**
-     * @param $string
-     * @return string
+     * @param $html
+     * @return html
      */
-    public function parse($string)
+    public function parse($html)
     {
-        preg_match_all('/<img .+>/isU', $string, $matches);
+        preg_match_all('/<img .+>/isU', $html, $matches);
         $images = $matches[0];
 
         $imagine = new Imagine();
 
         foreach ($images as $image) {
+            preg_match('/style="(.+)"/iU', $image, $style);
+            $style = ($style)? $style[1] : '';
+
             preg_match('/src="(.+)"/iU', $image, $src);
-            $src = $src[1];
+            preg_match('/width="([0-9]+)"/iU', $image, $width);
+            preg_match('/height="([0-9]+)"/iU', $image, $height);
+
+            if($width && $height && $src) {
+                // Resize image if necessary
+                $width = $width[1];
+                $height = $height[1];
+                $src = $src[1];
+
+                if($width > 600) {
+                    $height = 600*$height/$width;
+                }
+                if($height > 500) {
+                    $width = 500*$width/$height;
+                }
+
+                $html = str_replace($image, '<img src="'.$src.'" style="'.$style.';width:100%; max-width:'.$width.'px; height:auto;" width="'.$width.'" />', $html);
+            }
+            else if($src) {
+                $src = $src[1];
+                // Fallback on a 250x250px image
+                $html = str_replace($image, '<img src="'.$src.'" style="'.$style.';width:250px; height: 250px;" width="250" height="250" />', $html);
+            }
+            else {
+                // Remove image if we cannot find src field
+                $html = str_replace($image, '', $html);
+            }
+
+
             if (stripos('/uploads/', $src)) {
                 $path = explode('/uploads/', $src);
                 $path = $path[1];
@@ -42,11 +73,11 @@ class BodyParser
 
                 if ($size->getWidth() > 600) {
                     $replacement = '<img src="'.$src.'" style="width:600px; max-width: 100%;" width="600" />';
-                    $string = str_replace($image, $replacement, $string);
+                    $html = str_replace($image, $replacement, $html);
                 }
             }
         }
 
-        return $string;
+        return $html;
     }
 }

--- a/src/Etu/Module/DaymailBundle/Resources/views/Mail/daymail.html.twig
+++ b/src/Etu/Module/DaymailBundle/Resources/views/Mail/daymail.html.twig
@@ -14,7 +14,7 @@
 	<table style="width: 100%; background: #f5f5f5; border-collapse: collapse;">
 		<tr>
 			<td style="vertical-align: top; background: #363e4a; border-collapse: collapse;">
-				<table style="width: 600px; margin: 0 auto; border-collapse: collapse;">
+				<table style="max-width: 600px; width:100%; margin: 0 auto; border-collapse: collapse;">
 					<tr>
 						<td>
 							<img alt="EtuUTT" title="Logo de EtuUTT" src="http://etu.utt.fr/src/img/logo.png" />
@@ -34,7 +34,7 @@
 			<!---------------- Message ---------------->
 			<tr>
 				<td style="vertical-align: top; padding: 50px 10px 10px 10px; background: #ffffff; color: #333333; border-collapse: collapse; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
-					<table style="width: 600px; margin: 0 auto; border-collapse: collapse;">
+					<table style="max-width: 600px; width:100%; margin: 0 auto; border-collapse: collapse;">
 						<tr>
 							<td style="width: 60px;">
 								<img style="max-height: 50px; max-width: 50px;" alt="Logo" title="Logo de {{ part.orga.name }}" src="http://etu.utt.fr/uploads/logos/{{ part.orga.logo }}" />
@@ -55,7 +55,7 @@
 			</tr>
 			<tr>
 				<td style="vertical-align: top; padding: 20px 10px; color: #333333; text-align: justify; border-bottom: 3px solid #e5e5e5; border-collapse: collapse; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 14px;">
-					<table style="width: 600px; margin: 0 auto; border-collapse: collapse;">
+					<table style="max-width: 600px; width:100%; margin: 0 auto; border-collapse: collapse;">
 						<tr>
 							<td>
 								{{ part.body|raw }}
@@ -69,7 +69,7 @@
 
 		<tr>
 			<td style="vertical-align: top; padding: 20px 0 20px 0; text-align: center; background: #ffffff; color: #999999; border-collapse: collapse; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 11px;">
-				<table style="width: 600px; margin: 0 auto; border-collapse: collapse;">
+				<table style="max-width: 600px; width:100%; margin: 0 auto; border-collapse: collapse;">
 					<tr>
 						<td>
 							Généré et envoyé par le site étudiant de l'Université de Technologie de Troyes<br />

--- a/src/Etu/Module/DaymailBundle/Resources/views/Memberships/daymail.html.twig
+++ b/src/Etu/Module/DaymailBundle/Resources/views/Memberships/daymail.html.twig
@@ -24,6 +24,27 @@
 				'unorderedlist', '|', 'image', 'link'
 			]
 		});
+
+		var updateImgSizeAttr = function(){
+			$(this).find('img').each(function() {
+				// Force to keep ratio
+				if(!$(this).data('ratio')) {
+					$(this).data('ratio', parseInt($(this).css('width'))/parseInt($(this).css('height')));
+				}
+				else {
+					$(this).css('height', parseInt($(this).css('width'))/$(this).data('ratio'));
+				}
+
+				// Set width and height for php parsing
+				$(this).attr('width', parseInt($(this).css('width')));
+				$(this).attr('height', parseInt($(this).css('height')));
+			});
+			return true;
+		};
+
+		$('.redactor_redactor-html').bind("DOMSubtreeModified", updateImgSizeAttr);
+		$('#daymailform').submit(updateImgSizeAttr);
+
 	</script>
 
 	{% if wantPreview %}
@@ -130,7 +151,7 @@
 					</div>
 				</div>
 
-				<form method="post" action="">
+				<form id="daymailform" method="post" action="">
 					{{ form_errors(form) }}
 
 					<div class="control-group">


### PR DESCRIPTION
Since a lot of people are reading mail on their phone or on a mail client sidebar which is thinner than 600px. It's time for us to make it responsive and not forced to a width of 600px.

What's new:

* Daymail has now a `max-width` of `600px` and not a fixed width.
* User cannot change image ratio anymore on the WYSIWYG editor.
* Image width limit of pictures now applies to external pictures and not only pictures stored on the EtuUTT server. (Still limited to `600px`)
* Image height is now limited to `500px`
* Image will be reduced to fit in the screen no matter if it has reached a limit or not.