### PR TITLE
Fix A2I branch parsing

### DIFF
--- a/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToUpdate.php
+++ b/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToUpdate.php
@@ -82,7 +82,7 @@ class ElementToUpdate
         $niveau = null;
         $branch = $this->ldap->getNiveau();
 
-        preg_match('/^[^0-9]+/i', $this->ldap->getNiveau(), $match);
+        preg_match('/^(.+[^0-9])[0-9]{1,2}$/i', $this->ldap->getNiveau(), $match);
 
         if (isset($match[0])) {
             $branch = $match[0];


### PR DESCRIPTION
Les étudiants en `A2I1` sont mis dans la branche `A` avec le niveau `2I1` parce que une branche avec un chiffre dedans, c'était pas prévu. Du coup j'ai modifié le regex qui parse en considérant qu'une branche ne finira forcément pas par un chiffre.

Donc cette modification est censé régler le problème, mais je n'ai pas pus tester, parce que j'ai pas réussi à atteindre le serveur LDAP par le vpn.

Donc ça serait cool si quelqu'un pouvais tester pour voir si les gens en A2I, sont bien en A2I dans la bdd, et si les autres branches ne sont pas perturbés par cette modif (et pas tester sur la base de donnée de prod)

Merci :)