### PR TITLE
Bugfixe/ldap importation

### DIFF
--- a/src/Etu/Core/UserBundle/Entity/User.php
+++ b/src/Etu/Core/UserBundle/Entity/User.php
@@ -2146,6 +2146,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
     {
         $history = [
             'formation' => $this->formation,
+            'branch' => $this->branch,
             'niveau' => $this->niveau,
             'filiere' => $this->filiere,
             'uvs' => $this->getUvsList(),

--- a/src/Etu/Core/UserBundle/Ldap/LdapManager.php
+++ b/src/Etu/Core/UserBundle/Ldap/LdapManager.php
@@ -164,7 +164,6 @@ class LdapManager
             !isset($values['uid'])
             || !isset($values['supannempid'])
             || !isset($values['mail'])
-            || !isset($values['employeetype'])
         ) {
             $log = 'uid => '.$values['uid'][0]."\n";
 
@@ -184,6 +183,10 @@ class LdapManager
             $this->logs[] = $log;
 
             return false;
+        }
+
+        if (!isset($values['employeetype'])) {
+            $values['employeetype'] = [];
         }
 
         if (!isset($values['uv'])) {
@@ -207,7 +210,8 @@ class LdapManager
 
         $user->setIsStudent(
             in_array('student', $values['edupersonaffiliation'])
-                || in_array('student', $values['employeetype'])
+            || in_array('epf', $values['edupersonaffiliation']) // EPF students but not EPF staff
+            || in_array('student', $values['employeetype'])
         );
 
         $uvs = [];

--- a/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToImport.php
+++ b/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToImport.php
@@ -93,10 +93,10 @@ class ElementToImport
         $niveau = null;
         $branch = $this->element->getNiveau();
 
-        preg_match('/^[^0-9]+/i', $this->element->getNiveau(), $match);
+        preg_match('/^(.+)[0-9]$/i', $this->element->getNiveau(), $match);
 
-        if (isset($match[0])) {
-            $branch = $match[0];
+        if (isset($match[1])) {
+            $branch = $match[1];
             $niveau = str_replace($branch, '', $this->element->getNiveau());
         }
 

--- a/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToUpdate.php
+++ b/src/Etu/Core/UserBundle/Sync/Iterator/Element/ElementToUpdate.php
@@ -82,10 +82,10 @@ class ElementToUpdate
         $niveau = null;
         $branch = $this->ldap->getNiveau();
 
-        preg_match('/^[^0-9]+/i', $this->ldap->getNiveau(), $match);
+        preg_match('/^(.+)[0-9]$/i', $this->ldap->getNiveau(), $match);
 
-        if (isset($match[0])) {
-            $branch = $match[0];
+        if (isset($match[1])) {
+            $branch = $match[1];
             $niveau = str_replace($branch, '', $this->ldap->getNiveau());
         }
 


### PR DESCRIPTION
Résolution de différents bug qui apparaissent pendant l'importation depuis le LDAP de l'UTT:

* Les étudiants en A2I1 étaient mis dans la branche A avec le niveau 2I1 parce que une branche avec un chiffre dedans, c'était pas prévu. Du coup j'ai modifié le regex qui parse la branche.
* Les étudiants de l'EPF et les doctorants n'étaient pas reconnus en tant que personne car ils leur manque un champ dans le LDAP comparé aux étudiants et personnels de l'UTT.
* Il y a un champ "history" en bdd qui ne sert pas à grand chose pour le moment (à part générer un badge) et qui contient l'historique des semestres (Formation, Filière, niveau, Uvs). Jusque maintenant, il manquait la branche à cet ensemble de donnée, qui a pas beaucoup de sens sans elle.

fix #78 