### PR TITLE
RGPD prevent user profile pictures from being read directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ca.crt
 /web/uploads/photos/*
 !/web/uploads/photos/.gitkeep
 !/web/uploads/photos/default-avatar.png
+!/web/uploads/photos/.htaccess
 
 !/web/uploads/users_files
 /web/uploads/users_files/*

--- a/app/Resources/views/layout-default.html.twig
+++ b/app/Resources/views/layout-default.html.twig
@@ -79,7 +79,7 @@
                         <img src="{{ asset('uploads/logos/' ~ app.user.logo) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
                              title="{{ app.user.fullName }}" class="pull-left avatar" />
                     {% else %}
-                        <img src="{{ asset('uploads/photos/' ~ app.user.avatar) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
+                        <img src="{{ path("user_view_image_profil", {'login': app.user.avatar}) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
                              title="{{ app.user.fullName }}" class="pull-left avatar" />
                     {% endif %}
                 </a>

--- a/app/Resources/views/layout-default.html.twig
+++ b/app/Resources/views/layout-default.html.twig
@@ -79,7 +79,7 @@
                         <img src="{{ asset('uploads/logos/' ~ app.user.logo) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
                              title="{{ app.user.fullName }}" class="pull-left avatar" />
                     {% else %}
-                        <img src="{{ path("user_view_image_profil", {'login': app.user.avatar}) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
+                        <img src="{{ path("user_view_image_profil", {'avatar': app.user.avatar}) }}" id="top-bar-avatar" alt="{{ app.user.fullName }}"
                              title="{{ app.user.fullName }}" class="pull-left avatar" />
                     {% endif %}
                 </a>

--- a/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
@@ -127,16 +127,16 @@ class PublicUsersListController extends ApiController
      */
     public function viewImageAction($avatar)
     {
-        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
-        $cleanLogin = str_replace('..', '', $cleanLogin);
-        $path = __DIR__.'/../../../../../../web/uploads/photos/'.$cleanLogin;
+        $cleanAvatar = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
+        $cleanAvatar = str_replace('..', '', $cleanAvatar);
+        $path = __DIR__.'/../../../../../../web/uploads/photos/'.$cleanAvatar;
         if (!file_exists($path) || !mime_content_type($path)) {
             $path = __DIR__.'/../../../../../../web/uploads/photos/default-avatar.png';
         }
         $file = file_get_contents($path);
         $headers = [
             'Content-Type' => mime_content_type($path),
-            'Content-Disposition' => 'inline; filename="'.$cleanLogin.'"', ];
+            'Content-Disposition' => 'inline; filename="'.$cleanAvatar.'"', ];
 
         return new Response($file, 200, $headers);
     }

--- a/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
@@ -118,22 +118,22 @@ class PublicUsersListController extends ApiController
      *   }
      * )
      *
-     * @Route("/public/users/image/{login}", name="api_public_users_view")
+     * @Route("/public/users/image/{avatar}", name="api_public_users_view_image")
      * @Method("GET")
      *
-     * @param $login
+     * @param $avatar
      *
      * @return Response
      */
-    public function viewImageAction($login)
+    public function viewImageAction($avatar)
     {
-        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $login);
+        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
         $cleanLogin = str_replace('..', '', $cleanLogin);
-        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/'.$cleanLogin;
-        if (!file_exists($path) && mime_content_type($path)) {
-            $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
+        $path = __DIR__.'/../../../../../../web/uploads/photos/'.$cleanLogin;
+        if (!file_exists($path) || !mime_content_type($path)) {
+            $path = __DIR__.'/../../../../../../web/uploads/photos/default-avatar.png';
         }
-        $file = readfile($path);
+        $file = file_get_contents($path);
         $headers = [
             'Content-Type' => mime_content_type($path),
             'Content-Disposition' => 'inline; filename="'.$cleanLogin.'"', ];

--- a/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
@@ -120,7 +120,9 @@ class PublicUsersListController extends ApiController
      *
      * @Route("/public/users/image/{login}", name="api_public_users_view")
      * @Method("GET")
+     *
      * @param $login
+     *
      * @return Response
      */
     public function viewImageAction($login)

--- a/src/Etu/Core/UserBundle/Api/Transformer/UserPrivateTransformer.php
+++ b/src/Etu/Core/UserBundle/Api/Transformer/UserPrivateTransformer.php
@@ -13,9 +13,6 @@ class UserPrivateTransformer extends AbstractTransformer
      */
     protected $badgeTransformer;
 
-    /**
-     * @param BadgeTransformer $badgeTransformer
-     */
     public function __construct(BadgeTransformer $badgeTransformer)
     {
         $this->badgeTransformer = $badgeTransformer;
@@ -23,7 +20,6 @@ class UserPrivateTransformer extends AbstractTransformer
 
     /**
      * @param $user
-     * @param EmbedBag $includes
      *
      * @return array
      */
@@ -33,8 +29,6 @@ class UserPrivateTransformer extends AbstractTransformer
     }
 
     /**
-     * @param User $user
-     *
      * @return array
      */
     private function getData(User $user)
@@ -82,8 +76,6 @@ class UserPrivateTransformer extends AbstractTransformer
     }
 
     /**
-     * @param User $user
-     *
      * @return array
      */
     private function getLinks(User $user)
@@ -100,20 +92,17 @@ class UserPrivateTransformer extends AbstractTransformer
                 ],
                 [
                     'rel' => 'user.image',
-                    'uri' => '/uploads/photos/'.$user->getAvatar(),
+                    'uri' => '/api/public/users/image/'.$user->getAvatar(),
                 ],
                 [
                     'rel' => 'user.official_image',
-                    'uri' => '/uploads/photos/'.$user->getLogin().'_official.jpg',
+                    'uri' => '/api/public/users/image/'.$user->getLogin().'_official.jpg',
                 ],
             ],
         ];
     }
 
     /**
-     * @param User     $user
-     * @param EmbedBag $includes
-     *
      * @return array
      */
     private function getIncludes(User $user, EmbedBag $includes)
@@ -139,7 +128,7 @@ class UserPrivateTransformer extends AbstractTransformer
 
     protected function displayPrivacy($privacy)
     {
-        if ($privacy == User::PRIVACY_PUBLIC) {
+        if (User::PRIVACY_PUBLIC == $privacy) {
             return 'public';
         }
 

--- a/src/Etu/Core/UserBundle/Api/Transformer/UserTransformer.php
+++ b/src/Etu/Core/UserBundle/Api/Transformer/UserTransformer.php
@@ -19,8 +19,7 @@ class UserTransformer extends AbstractTransformer
     protected $kernelRootDir;
 
     /**
-     * @param BadgeTransformer $badgeTransformer
-     * @param string           $kernelRootDir    path to app directory
+     * @param string $kernelRootDir path to app directory
      */
     public function __construct(BadgeTransformer $badgeTransformer, $kernelRootDir)
     {
@@ -30,7 +29,6 @@ class UserTransformer extends AbstractTransformer
 
     /**
      * @param $user
-     * @param EmbedBag $includes
      *
      * @return array
      */
@@ -40,8 +38,6 @@ class UserTransformer extends AbstractTransformer
     }
 
     /**
-     * @param User $user
-     *
      * @return array
      */
     private function getData(User $user)
@@ -53,14 +49,14 @@ class UserTransformer extends AbstractTransformer
             'firstName' => $user->getFirstName(),
             'lastName' => $user->getLastName(),
             'fullName' => $user->getFullName(),
-            'personalMail' => $user->getPersonnalMailPrivacy() == User::PRIVACY_PUBLIC ? $user->getPersonnalMail() : null,
-            'phone' => $user->getPhoneNumberPrivacy() == User::PRIVACY_PUBLIC ? $user->getPhoneNumber() : null,
-            'nationality' => $user->getNationalityPrivacy() == User::PRIVACY_PUBLIC ? $user->getNationality() : null,
-            'address' => $user->getAddressPrivacy() == User::PRIVACY_PUBLIC ? $user->getAddress() : null,
-            'country' => $user->getCountryPrivacy() == User::PRIVACY_PUBLIC ? $user->getCountry() : null,
-            'postalCode' => $user->getPostalCodePrivacy() == User::PRIVACY_PUBLIC ? $user->getPostalCode() : null,
-            'city' => $user->getCityPrivacy() == User::PRIVACY_PUBLIC ? $user->getCity() : null,
-            'sex' => $user->getSexPrivacy() == User::PRIVACY_PUBLIC ? $user->getSex() : null,
+            'personalMail' => User::PRIVACY_PUBLIC == $user->getPersonnalMailPrivacy() ? $user->getPersonnalMail() : null,
+            'phone' => User::PRIVACY_PUBLIC == $user->getPhoneNumberPrivacy() ? $user->getPhoneNumber() : null,
+            'nationality' => User::PRIVACY_PUBLIC == $user->getNationalityPrivacy() ? $user->getNationality() : null,
+            'address' => User::PRIVACY_PUBLIC == $user->getAddressPrivacy() ? $user->getAddress() : null,
+            'country' => User::PRIVACY_PUBLIC == $user->getCountryPrivacy() ? $user->getCountry() : null,
+            'postalCode' => User::PRIVACY_PUBLIC == $user->getPostalCodePrivacy() ? $user->getPostalCode() : null,
+            'city' => User::PRIVACY_PUBLIC == $user->getCityPrivacy() ? $user->getCity() : null,
+            'sex' => User::PRIVACY_PUBLIC == $user->getSexPrivacy() ? $user->getSex() : null,
             'formation' => $user->getFormation(),
             'branch' => $user->getBranch(),
             'level' => $user->getNiveau(),
@@ -68,7 +64,7 @@ class UserTransformer extends AbstractTransformer
             'surname' => $user->getSurnom(),
             'jadis' => $user->getJadis(),
             'passions' => $user->getPassions(),
-            'birthday' => ($user->getBirthdayPrivacy() == User::PRIVACY_PUBLIC && $user->getBirthday()) ? $user->getBirthday()->format(\DateTime::ISO8601) : null,
+            'birthday' => (User::PRIVACY_PUBLIC == $user->getBirthdayPrivacy() && $user->getBirthday()) ? $user->getBirthday()->format(\DateTime::ISO8601) : null,
             'website' => $user->getWebsite(),
             'facebook' => $user->getFacebook(),
             'uvs' => $user->getUvsList(),
@@ -82,8 +78,6 @@ class UserTransformer extends AbstractTransformer
     }
 
     /**
-     * @param User $user
-     *
      * @return array
      */
     private function getLinks(User $user)
@@ -99,17 +93,17 @@ class UserTransformer extends AbstractTransformer
             ],
             [
                 'rel' => 'user.image',
-                'uri' => '/uploads/photos/'.$user->getAvatar(),
+                'uri' => '/api/public/users/image/'.$user->getAvatar(),
             ],
         ];
 
         // add official image only if it exists
         $officialImage = [
             'rel' => 'user.official_image',
-            'uri' => '/uploads/photos/'.$user->getLogin().'_official.jpg',
+            'uri' => '/api/public/users/image/'.$user->getLogin().'_official.jpg',
         ];
 
-        if (file_exists($this->kernelRootDir.'/../web'.$officialImage['uri'])) {
+        if (file_exists($this->kernelRootDir.'/../web/uploads/photos/'.$user->getLogin().'_official.jpg')) {
             array_push($links, $officialImage);
         }
 
@@ -119,9 +113,6 @@ class UserTransformer extends AbstractTransformer
     }
 
     /**
-     * @param User     $user
-     * @param EmbedBag $includes
-     *
      * @return array
      */
     private function getIncludes(User $user, EmbedBag $includes)

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -383,14 +383,16 @@ class ProfileController extends Controller
     public function viewImageProfil($login)
     {
         $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
-        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/'.$login;
+        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $login);
+        $cleanLogin = str_replace('..', '', $cleanLogin);
+        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/'.$cleanLogin;
         if (!file_exists($path) && mime_content_type($path)) {
             $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
         }
         $file = readfile($path);
         $headers = [
             'Content-Type' => mime_content_type($path),
-            'Content-Disposition' => 'inline; filename="'.$login.'"', ];
+            'Content-Disposition' => 'inline; filename="'.$cleanLogin.'"', ];
 
         return new Response($file, 200, $headers);
     }

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class ProfileController extends Controller
 {
@@ -370,6 +371,24 @@ class ProfileController extends Controller
             'user' => $user,
             'from' => $from,
         ];
+    }
+
+    /**
+     * @Route("/images/profil/{login}", name="user_view_image_profil")
+     * @param $login
+     * @return Response
+     */
+    public function viewImageProfil($login)
+    {
+        $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
+        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/' . $login;
+        if(!file_exists($path))
+            $path=$this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
+        $file =    readfile($path);
+        $headers = array(
+            'Content-Type'     => 'image/png',
+            'Content-Disposition' => 'inline; filename="'.$login.'"');
+        return new Response($file, 200, $headers);
     }
 
     /**

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -208,7 +208,7 @@ class ProfileController extends Controller
             $em = $this->getDoctrine()->getManager();
 
             // Badges
-            if ($user->getProfileCompletion() == 100) {
+            if (100 == $user->getProfileCompletion()) {
                 BadgesManager::userAddBadge($user, 'profile_completed');
             } else {
                 BadgesManager::userRemoveBadge($user, 'profile_completed');
@@ -315,7 +315,7 @@ class ProfileController extends Controller
         if ($form->isSubmitted() && $form->isValid()) {
             $em = $this->getDoctrine()->getManager();
 
-            if ($user->getTrombiCompletion() == 100) {
+            if (100 == $user->getTrombiCompletion()) {
                 BadgesManager::userAddBadge($user, 'trombi_completed');
             } else {
                 BadgesManager::userRemoveBadge($user, 'trombi_completed');
@@ -363,7 +363,7 @@ class ProfileController extends Controller
 
         $from = null;
 
-        if (in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
+        if (\in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
             $from = $request->get('from');
         }
 
@@ -375,19 +375,23 @@ class ProfileController extends Controller
 
     /**
      * @Route("/images/profil/{login}", name="user_view_image_profil")
+     *
      * @param $login
+     *
      * @return Response
      */
     public function viewImageProfil($login)
     {
         $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
-        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/' . $login;
-        if(!file_exists($path))
-            $path=$this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
-        $file =    readfile($path);
-        $headers = array(
-            'Content-Type'     => 'image/png',
-            'Content-Disposition' => 'inline; filename="'.$login.'"');
+        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/'.$login;
+        if (!file_exists($path) && mime_content_type($path)) {
+            $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
+        }
+        $file = readfile($path);
+        $headers = [
+            'Content-Type' => mime_content_type($path),
+            'Content-Disposition' => 'inline; filename="'.$login.'"', ];
+
         return new Response($file, 200, $headers);
     }
 
@@ -424,7 +428,7 @@ class ProfileController extends Controller
 
         $from = null;
 
-        if (in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
+        if (\in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
             $from = $request->get('from');
         }
 
@@ -462,7 +466,7 @@ class ProfileController extends Controller
 
         $from = null;
 
-        if (in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
+        if (\in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
             $from = $request->get('from');
         }
 
@@ -481,8 +485,8 @@ class ProfileController extends Controller
             Course::DAY_THURSDAY, Course::DAY_FRIDAY, Course::DAY_SATHURDAY,
         ];
 
-        if (!in_array($day, $days)) {
-            if (date('w') == 0) { // Sunday
+        if (!\in_array($day, $days)) {
+            if (0 == date('w')) { // Sunday
                 $day = Course::DAY_MONDAY;
             } else {
                 $day = $days[date('w') - 1];
@@ -523,7 +527,7 @@ class ProfileController extends Controller
 
         $from = null;
 
-        if (in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
+        if (\in_array($request->get('from'), ['search', 'profile', 'trombi', 'admin'])) {
             $from = $request->get('from');
         }
 

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -374,16 +374,16 @@ class ProfileController extends Controller
     }
 
     /**
-     * @Route("/images/profil/{login}", name="user_view_image_profil")
+     * @Route("/images/profil/{avatar}", name="user_view_image_profil")
      *
-     * @param $login
+     * @param $avatar
      *
      * @return Response
      */
-    public function viewImageProfil($login)
+    public function viewImageProfil($avatar)
     {
         $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
-        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $login);
+        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
         $cleanLogin = str_replace('..', '', $cleanLogin);
         $path = __DIR__.'/../../../../../web/uploads/photos/'.$cleanLogin;
         if (!file_exists($path) || !mime_content_type($path)) {

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -385,11 +385,11 @@ class ProfileController extends Controller
         $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
         $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $login);
         $cleanLogin = str_replace('..', '', $cleanLogin);
-        $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/'.$cleanLogin;
-        if (!file_exists($path) && mime_content_type($path)) {
-            $path = $this->get('kernel')->getProjectDir().'/web/uploads/photos/default-avatar.png';
+        $path = __DIR__.'/../../../../../web/uploads/photos/'.$cleanLogin;
+        if (!file_exists($path) || !mime_content_type($path)) {
+            $path = __DIR__.'/../../../../../web/uploads/photos/default-avatar.png';
         }
-        $file = readfile($path);
+        $file = file_get_contents($path);
         $headers = [
             'Content-Type' => mime_content_type($path),
             'Content-Disposition' => 'inline; filename="'.$cleanLogin.'"', ];

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -383,16 +383,16 @@ class ProfileController extends Controller
     public function viewImageProfil($avatar)
     {
         $this->denyAccessUnlessGranted('ROLE_CORE_PROFIL');
-        $cleanLogin = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
-        $cleanLogin = str_replace('..', '', $cleanLogin);
-        $path = __DIR__.'/../../../../../web/uploads/photos/'.$cleanLogin;
+        $cleanAvatar = preg_replace('/[^a-zA-Z0-9.]/', '', $avatar);
+        $cleanAvatar = str_replace('..', '', $cleanAvatar);
+        $path = __DIR__.'/../../../../../web/uploads/photos/'.$cleanAvatar;
         if (!file_exists($path) || !mime_content_type($path)) {
             $path = __DIR__.'/../../../../../web/uploads/photos/default-avatar.png';
         }
         $file = file_get_contents($path);
         $headers = [
             'Content-Type' => mime_content_type($path),
-            'Content-Disposition' => 'inline; filename="'.$cleanLogin.'"', ];
+            'Content-Disposition' => 'inline; filename="'.$cleanAvatar.'"', ];
 
         return new Response($file, 200, $headers);
     }

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userAvatar.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userAvatar.html.twig
@@ -17,7 +17,7 @@
     </ul>
 
     <div class="padding20-sides profile-avatar">
-        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+        <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
         <hr/>
         {{ form_start(form) }}
         {{ form_widget(form) }}

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userAvatar.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userAvatar.html.twig
@@ -17,7 +17,7 @@
     </ul>
 
     <div class="padding20-sides profile-avatar">
-        <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
         <hr/>
         {{ form_start(form) }}
         {{ form_widget(form) }}

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userEdit.html.twig
@@ -36,7 +36,7 @@
                     <div class="profileEdit-avatar-actions">
                         <i class="icon-pencil"></i>
                     </div>
-                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="profileEdit-avatar"
+                    <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" class="profileEdit-avatar"
                          alt="{{ user.fullName }}" id="avatar-image" />
                 </a>
             </div>

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userEdit.html.twig
@@ -36,7 +36,7 @@
                     <div class="profileEdit-avatar-actions">
                         <i class="icon-pencil"></i>
                     </div>
-                    <img src="{{ asset('uploads/photos/'~user.avatar) }}" class="profileEdit-avatar"
+                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="profileEdit-avatar"
                          alt="{{ user.fullName }}" id="avatar-image" />
                 </a>
             </div>

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userRoles.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userRoles.html.twig
@@ -35,7 +35,7 @@
             <div class="row-fluid">
                 <div class="span4">
                     <div class="profileEdit-avatar">
-                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span8">

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userRoles.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userRoles.html.twig
@@ -35,7 +35,7 @@
             <div class="row-fluid">
                 <div class="span4">
                     <div class="profileEdit-avatar">
-                        <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span8">

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userRolesList.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userRolesList.html.twig
@@ -28,7 +28,7 @@
             <div class="row-fluid">
                 <div class="span2">
                     <div class="profileEdit-avatar" style="text-align:center;">
-                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span10">

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/userRolesList.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/userRolesList.html.twig
@@ -28,7 +28,7 @@
             <div class="row-fluid">
                 <div class="span2">
                     <div class="profileEdit-avatar" style="text-align:center;">
-                        <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span10">

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/usersIndex.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/usersIndex.html.twig
@@ -92,7 +92,7 @@
                 {% for user in pagination %}
                     <li class="trombi-search-results-item">
                         <a href="{{ path('user_view', {'login': user.login}) }}?from=admin">
-                            <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                             <h5>{{ user.fullName }}</h5>
                             <p>
                                 {{ user.branch~user.niveau }} {{ user.filiere }} ({{ user.formation }})<br />

--- a/src/Etu/Core/UserBundle/Resources/views/Admin/usersIndex.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Admin/usersIndex.html.twig
@@ -92,7 +92,7 @@
                 {% for user in pagination %}
                     <li class="trombi-search-results-item">
                         <a href="{{ path('user_view', {'login': user.login}) }}?from=admin">
-                            <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                             <h5>{{ user.fullName }}</h5>
                             <p>
                                 {{ user.branch~user.niveau }} {{ user.filiere }} ({{ user.formation }})<br />

--- a/src/Etu/Core/UserBundle/Resources/views/Memberships/permissions.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Memberships/permissions.html.twig
@@ -16,7 +16,7 @@
         {% for member in pagination %}
             <li class="asso-members-item asso-members-item-member">
                 <a href="{{ path('memberships_orga_permissions_edit', {'login': membership.organization.login, 'user': member.user.login}) }}">
-                    <img src="{{ asset('uploads/photos/'~member.user.avatar) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                    <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                     <h5>{{ member.user.fullName }}</h5>
                     <p>
                         {{ ('user.orga.role.'~member.role)|trans }}

--- a/src/Etu/Core/UserBundle/Resources/views/Memberships/permissions.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Memberships/permissions.html.twig
@@ -16,7 +16,7 @@
         {% for member in pagination %}
             <li class="asso-members-item asso-members-item-member">
                 <a href="{{ path('memberships_orga_permissions_edit', {'login': membership.organization.login, 'user': member.user.login}) }}">
-                    <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                    <img src="{{ path('user_view_image_profil', {'avatar': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                     <h5>{{ member.user.fullName }}</h5>
                     <p>
                         {{ ('user.orga.role.'~member.role)|trans }}

--- a/src/Etu/Core/UserBundle/Resources/views/Memberships/permissionsEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Memberships/permissionsEdit.html.twig
@@ -10,7 +10,7 @@
 {% block membership_content %}
     <div class="row-fluid">
         <div class="span2">
-            <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+            <img src="{{ path('user_view_image_profil', {'avatar': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
         </div>
         <div class="span10">
             <p>

--- a/src/Etu/Core/UserBundle/Resources/views/Memberships/permissionsEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Memberships/permissionsEdit.html.twig
@@ -10,7 +10,7 @@
 {% block membership_content %}
     <div class="row-fluid">
         <div class="span2">
-            <img src="{{ asset('uploads/photos/'~member.user.avatar) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+            <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
         </div>
         <div class="span10">
             <p>

--- a/src/Etu/Core/UserBundle/Resources/views/Orga/memberEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Orga/memberEdit.html.twig
@@ -22,7 +22,7 @@
             <div class="row-fluid">
                 <div class="span4">
                     <div class="profileEdit-avatar">
-                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span8">

--- a/src/Etu/Core/UserBundle/Resources/views/Orga/memberEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Orga/memberEdit.html.twig
@@ -22,7 +22,7 @@
             <div class="row-fluid">
                 <div class="span4">
                     <div class="profileEdit-avatar">
-                        <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                     </div>
                 </div>
                 <div class="span8">

--- a/src/Etu/Core/UserBundle/Resources/views/Orga/members.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Orga/members.html.twig
@@ -53,7 +53,7 @@
             {% for member in group.members %}
                 <li class="asso-members-item">
                     <a href="{{ path('orga_admin_members_edit', {'login': member.user.login}) }}">
-                        <img src="{{ asset('uploads/photos/'~member.user.avatar) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                         <h5>{{ member.user.fullName }}</h5>
                         <p>
                             {{ ('user.orga.role.'~member.role)|trans }}

--- a/src/Etu/Core/UserBundle/Resources/views/Orga/members.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Orga/members.html.twig
@@ -53,7 +53,7 @@
             {% for member in group.members %}
                 <li class="asso-members-item">
                     <a href="{{ path('orga_admin_members_edit', {'login': member.user.login}) }}">
-                        <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                         <h5>{{ member.user.fullName }}</h5>
                         <p>
                             {{ ('user.orga.role.'~member.role)|trans }}

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/badges.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/badges.html.twig
@@ -64,7 +64,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/badges.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/badges.html.twig
@@ -64,7 +64,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ asset('uploads/photos/'~user.avatar) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/organizations.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/organizations.html.twig
@@ -63,7 +63,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/organizations.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/organizations.html.twig
@@ -63,7 +63,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ asset('uploads/photos/'~user.avatar) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profileAvatar.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profileAvatar.html.twig
@@ -17,7 +17,7 @@
     </ul>
 
     <div class="padding20-sides profile-avatar">
-        <img src="{{ asset('uploads/photos/'~app.user.avatar) }}" alt="{{ app.user.fullName }}" title="{{ app.user.fullName }}" />
+        <img src="{{ path('user_view_image_profil', {'login': app.user.avatar}) }}" alt="{{ app.user.fullName }}" title="{{ app.user.fullName }}" />
         <hr/>
         {{ form_start(form) }}
         {{ form_widget(form) }}

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profileAvatar.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profileAvatar.html.twig
@@ -17,7 +17,7 @@
     </ul>
 
     <div class="padding20-sides profile-avatar">
-        <img src="{{ path('user_view_image_profil', {'login': app.user.avatar}) }}" alt="{{ app.user.fullName }}" title="{{ app.user.fullName }}" />
+        <img src="{{ path('user_view_image_profil', {'avatar': app.user.avatar}) }}" alt="{{ app.user.fullName }}" title="{{ app.user.fullName }}" />
         <hr/>
         {{ form_start(form) }}
         {{ form_widget(form) }}

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
@@ -35,7 +35,7 @@
                     <div class="profileEdit-avatar-actions">
                         <i class="icon-pencil"></i>
                     </div>
-                    <img src="{{ asset('uploads/photos/'~app.user.avatar) }}" class="profileEdit-avatar"
+                    <img src="{{ path('user_view_image_profil', {'login': app.user.avatar}) }}" class="profileEdit-avatar"
                          alt="{{ app.user.fullName }}" id="avatar-image" />
                 </a>
             </div>

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
@@ -35,7 +35,7 @@
                     <div class="profileEdit-avatar-actions">
                         <i class="icon-pencil"></i>
                     </div>
-                    <img src="{{ path('user_view_image_profil', {'login': app.user.avatar}) }}" class="profileEdit-avatar"
+                    <img src="{{ path('user_view_image_profil', {'avatar': app.user.avatar}) }}" class="profileEdit-avatar"
                          alt="{{ app.user.fullName }}" id="avatar-image" />
                 </a>
             </div>

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/schedule.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/schedule.html.twig
@@ -63,7 +63,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ asset('uploads/photos/'~user.avatar) }}" class="view-avatar hidden-phone"
+                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar hidden-phone"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/schedule.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/schedule.html.twig
@@ -63,7 +63,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar hidden-phone"
+                    <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" class="view-avatar hidden-phone"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/view.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/view.html.twig
@@ -79,7 +79,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/view.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/view.html.twig
@@ -79,7 +79,7 @@
         <div class="row-fluid">
             <div class="span3">
                 <div class="align-center">
-                    <img src="{{ asset('uploads/photos/'~user.avatar) }}" class="view-avatar"
+                    <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" class="view-avatar"
                          alt="{{ user.fullName }}" title="{{ user.fullName }}" />
 
                     <hr />

--- a/src/Etu/Core/UserBundle/Resources/views/Schedule/course.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Schedule/course.html.twig
@@ -35,7 +35,7 @@
                 {% for student in students %}
                     <li class="asso-members-item asso-members-item-member">
                         <a href="{{ path('user_view', {'login': student.user.login}) }}">
-                            <img src="{{ asset('uploads/photos/'~student.user.avatar) }}" alt="{{ student.user.fullName }}" title="{{ student.user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'login': student.user.avatar}) }}" alt="{{ student.user.fullName }}" title="{{ student.user.fullName }}" />
                             <h5>{{ student.user.fullName }}</h5>
                             <p>
                                 {{ student.user.branch~student.user.niveau }} {{ student.user.filiere }}

--- a/src/Etu/Core/UserBundle/Resources/views/Schedule/course.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Schedule/course.html.twig
@@ -35,7 +35,7 @@
                 {% for student in students %}
                     <li class="asso-members-item asso-members-item-member">
                         <a href="{{ path('user_view', {'login': student.user.login}) }}">
-                            <img src="{{ path('user_view_image_profil', {'login': student.user.avatar}) }}" alt="{{ student.user.fullName }}" title="{{ student.user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'avatar': student.user.avatar}) }}" alt="{{ student.user.fullName }}" title="{{ student.user.fullName }}" />
                             <h5>{{ student.user.fullName }}</h5>
                             <p>
                                 {{ student.user.branch~student.user.niveau }} {{ student.user.filiere }}

--- a/src/Etu/Module/AssosBundle/Resources/views/Main/members.html.twig
+++ b/src/Etu/Module/AssosBundle/Resources/views/Main/members.html.twig
@@ -102,7 +102,7 @@
                             {% for member in group.members %}
                                 <li class="asso-members-item asso-members-item-office">
                                     <a href="{{ path('user_view', {'login': member.user.login}) }}">
-                                        <img src="{{ asset('uploads/photos/'~member.user.avatar) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                                        <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                                         <h5>{{ member.user.fullName }}</h5>
                                         <p>
                                             {{ ('user.orga.role.'~member.role)|trans }}<br />

--- a/src/Etu/Module/AssosBundle/Resources/views/Main/members.html.twig
+++ b/src/Etu/Module/AssosBundle/Resources/views/Main/members.html.twig
@@ -102,7 +102,7 @@
                             {% for member in group.members %}
                                 <li class="asso-members-item asso-members-item-office">
                                     <a href="{{ path('user_view', {'login': member.user.login}) }}">
-                                        <img src="{{ path('user_view_image_profil', {'login': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
+                                        <img src="{{ path('user_view_image_profil', {'avatar': member.user.avatar}) }}" alt="{{ member.user.fullName }}" title="{{ member.user.fullName }}" />
                                         <h5>{{ member.user.fullName }}</h5>
                                         <p>
                                             {{ ('user.orga.role.'~member.role)|trans }}<br />

--- a/src/Etu/Module/BadgesBundle/Resources/views/Admin/users.html.twig
+++ b/src/Etu/Module/BadgesBundle/Resources/views/Admin/users.html.twig
@@ -41,7 +41,7 @@
       {% for membership in memberships %}
         <li class="badge-users-item">
           <a href="{{ path('user_view', {'login': membership.user.login}) }}">
-            <img src="{{ asset('uploads/photos/'~membership.user.avatar) }}" alt="{{ membership.user.fullName }}" title="{{ membership.user.fullName }}"/>
+            <img src="{{ path('user_view_image_profil', {'login': membership.user.avatar}) }}" alt="{{ membership.user.fullName }}" title="{{ membership.user.fullName }}"/>
             <h5>{{ membership.user.fullName }}</h5>
 
             <div class="clear"></div>

--- a/src/Etu/Module/BadgesBundle/Resources/views/Admin/users.html.twig
+++ b/src/Etu/Module/BadgesBundle/Resources/views/Admin/users.html.twig
@@ -41,7 +41,7 @@
       {% for membership in memberships %}
         <li class="badge-users-item">
           <a href="{{ path('user_view', {'login': membership.user.login}) }}">
-            <img src="{{ path('user_view_image_profil', {'login': membership.user.avatar}) }}" alt="{{ membership.user.fullName }}" title="{{ membership.user.fullName }}"/>
+            <img src="{{ path('user_view_image_profil', {'avatar': membership.user.avatar}) }}" alt="{{ membership.user.fullName }}" title="{{ membership.user.fullName }}"/>
             <h5>{{ membership.user.fullName }}</h5>
 
             <div class="clear"></div>

--- a/src/Etu/Module/BugsBundle/Resources/views/Bugs/view.html.twig
+++ b/src/Etu/Module/BugsBundle/Resources/views/Bugs/view.html.twig
@@ -126,7 +126,7 @@
         <div class="etu-comment" id="1">
             <div class="etu-comment-avatar">
                 <a href="{{ path('user_view', {'login': bug.user.login}) }}">
-                    <img src="{{ asset('uploads/photos/'~bug.user.avatar) }}" />
+                    <img src="{{ path('user_view_image_profil', {'login': bug.user.avatar}) }}" />
                 </a>
             </div>
             <div class="etu-comment-infos">
@@ -188,7 +188,7 @@
                 <div class="etu-comment" id="{{ count }}">
                     <div class="etu-comment-avatar">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                            <img src="{{ asset('uploads/photos/'~comment.user.avatar) }}" />
+                            <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" />
                         </a>
                     </div>
                     <div class="etu-comment-infos">

--- a/src/Etu/Module/BugsBundle/Resources/views/Bugs/view.html.twig
+++ b/src/Etu/Module/BugsBundle/Resources/views/Bugs/view.html.twig
@@ -126,7 +126,7 @@
         <div class="etu-comment" id="1">
             <div class="etu-comment-avatar">
                 <a href="{{ path('user_view', {'login': bug.user.login}) }}">
-                    <img src="{{ path('user_view_image_profil', {'login': bug.user.avatar}) }}" />
+                    <img src="{{ path('user_view_image_profil', {'avatar': bug.user.avatar}) }}" />
                 </a>
             </div>
             <div class="etu-comment-infos">
@@ -188,7 +188,7 @@
                 <div class="etu-comment" id="{{ count }}">
                     <div class="etu-comment-avatar">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                            <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" />
+                            <img src="{{ path('user_view_image_profil', {'avatar': comment.user.avatar}) }}" />
                         </a>
                     </div>
                     <div class="etu-comment-infos">

--- a/src/Etu/Module/CovoitBundle/Resources/views/Public/view.html.twig
+++ b/src/Etu/Module/CovoitBundle/Resources/views/Public/view.html.twig
@@ -203,7 +203,7 @@
                 <div class="etu-comment" id="{{ message.id }}">
                     <div class="etu-comment-avatar">
                         <a href="{{ path('user_view', {'login': message.author.login}) }}">
-                            <img src="{{ path('user_view_image_profil', {'login': message.author.avatar}) }}"
+                            <img src="{{ path('user_view_image_profil', {'avatar': message.author.avatar}) }}"
                                  alt="{{ message.author.getFullName() }}"
                                  title="{{ message.author.getFullName() }}"/>
                         </a>

--- a/src/Etu/Module/CovoitBundle/Resources/views/Public/view.html.twig
+++ b/src/Etu/Module/CovoitBundle/Resources/views/Public/view.html.twig
@@ -203,7 +203,7 @@
                 <div class="etu-comment" id="{{ message.id }}">
                     <div class="etu-comment-avatar">
                         <a href="{{ path('user_view', {'login': message.author.login}) }}">
-                            <img src="{{ asset('uploads/photos/' ~ message.author.avatar) }}"
+                            <img src="{{ path('user_view_image_profil', {'login': message.author.avatar}) }}"
                                  alt="{{ message.author.getFullName() }}"
                                  title="{{ message.author.getFullName() }}"/>
                         </a>

--- a/src/Etu/Module/CumulBundle/Resources/views/Main/index.html.twig
+++ b/src/Etu/Module/CumulBundle/Resources/views/Main/index.html.twig
@@ -225,7 +225,7 @@
             <div class="comparison-generator">
                 {% for user in users %}
                     <div class="comparison-generator-user">
-                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" />
                         {{ user.fullName|limit(18) }}
 
                         {% if countUsers > 1 %}

--- a/src/Etu/Module/CumulBundle/Resources/views/Main/index.html.twig
+++ b/src/Etu/Module/CumulBundle/Resources/views/Main/index.html.twig
@@ -225,7 +225,7 @@
             <div class="comparison-generator">
                 {% for user in users %}
                     <div class="comparison-generator-user">
-                        <img src="{{ asset('uploads/photos/' ~ user.avatar) }}" />
+                        <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" />
                         {{ user.fullName|limit(18) }}
 
                         {% if countUsers > 1 %}

--- a/src/Etu/Module/ForumBundle/Resources/views/Main/thread.html.twig
+++ b/src/Etu/Module/ForumBundle/Resources/views/Main/thread.html.twig
@@ -91,7 +91,7 @@
             <div class="etu-comment" id="{{ message.id }}">
                 <div class="etu-comment-avatar">
                     <a href="{{ path('user_view', {'login': message.author.login}) }}">
-                        <img src="{{ path('user_view_image_profil', {'login': message.author.avatar}) }}"
+                        <img src="{{ path('user_view_image_profil', {'avatar': message.author.avatar}) }}"
                              alt="{{ message.author.getFullName() }}"
                              title="{{ message.author.getFullName() }}"/>
                     </a>

--- a/src/Etu/Module/ForumBundle/Resources/views/Main/thread.html.twig
+++ b/src/Etu/Module/ForumBundle/Resources/views/Main/thread.html.twig
@@ -91,7 +91,7 @@
             <div class="etu-comment" id="{{ message.id }}">
                 <div class="etu-comment-avatar">
                     <a href="{{ path('user_view', {'login': message.author.login}) }}">
-                        <img src="{{ asset('uploads/photos/'~message.author.avatar) }}"
+                        <img src="{{ path('user_view_image_profil', {'login': message.author.avatar}) }}"
                              alt="{{ message.author.getFullName() }}"
                              title="{{ message.author.getFullName() }}"/>
                     </a>

--- a/src/Etu/Module/TrombiBundle/Resources/views/Main/index.html.twig
+++ b/src/Etu/Module/TrombiBundle/Resources/views/Main/index.html.twig
@@ -158,7 +158,7 @@
                     {% for user in pagination %}
                     <li class="trombi-search-results-item">
                         <a href="{{ path('user_view', {'login': user.login}) }}?from=trombi">
-                            <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'avatar': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                             <h5>
                                 {{ user.fullName }}
                                 {% if user.surnom and is_granted('ROLE_CORE_PROFIL_HOBBIES') %}

--- a/src/Etu/Module/TrombiBundle/Resources/views/Main/index.html.twig
+++ b/src/Etu/Module/TrombiBundle/Resources/views/Main/index.html.twig
@@ -158,7 +158,7 @@
                     {% for user in pagination %}
                     <li class="trombi-search-results-item">
                         <a href="{{ path('user_view', {'login': user.login}) }}?from=trombi">
-                            <img src="{{ asset('uploads/photos/'~user.avatar) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
+                            <img src="{{ path('user_view_image_profil', {'login': user.avatar}) }}" alt="{{ user.fullName }}" title="{{ user.fullName }}" />
                             <h5>
                                 {{ user.fullName }}
                                 {% if user.surnom and is_granted('ROLE_CORE_PROFIL_HOBBIES') %}

--- a/src/Etu/Module/UVBundle/Resources/views/Admin/comments.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/Admin/comments.html.twig
@@ -21,7 +21,7 @@
         {% for comment in pagination %}
             <div class="uv-view-comment">
                 <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                    <img src="{{ asset('uploads/photos/'~comment.user.avatar) }}" class="uv-view-comment-avatar" />
+                    <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                 </a>
                 <div class="uv-view-comment-author">
                     <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/src/Etu/Module/UVBundle/Resources/views/Admin/comments.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/Admin/comments.html.twig
@@ -21,7 +21,7 @@
         {% for comment in pagination %}
             <div class="uv-view-comment">
                 <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                    <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
+                    <img src="{{ path('user_view_image_profil', {'avatar': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                 </a>
                 <div class="uv-view-comment-author">
                     <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/src/Etu/Module/UVBundle/Resources/views/Admin/index.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/Admin/index.html.twig
@@ -56,7 +56,7 @@
                 {% for comment in comments %}
                     <div class="uv-view-comment">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                            <img src="{{ asset('uploads/photos/'~comment.user.avatar) }}" class="uv-view-comment-avatar" />
+                            <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                         </a>
                         <div class="uv-view-comment-author">
                             <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/src/Etu/Module/UVBundle/Resources/views/Admin/index.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/Admin/index.html.twig
@@ -56,7 +56,7 @@
                 {% for comment in comments %}
                     <div class="uv-view-comment">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                            <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
+                            <img src="{{ path('user_view_image_profil', {'avatar': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                         </a>
                         <div class="uv-view-comment-author">
                             <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/src/Etu/Module/UVBundle/Resources/views/View/view.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/View/view.html.twig
@@ -241,7 +241,7 @@
             {% for comment in pagination %}
                 <div class="uv-view-comment">
                     <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                        <img src="{{ asset('uploads/photos/'~comment.user.avatar) }}" class="uv-view-comment-avatar" />
+                        <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                     </a>
                     <div class="uv-view-comment-author">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/src/Etu/Module/UVBundle/Resources/views/View/view.html.twig
+++ b/src/Etu/Module/UVBundle/Resources/views/View/view.html.twig
@@ -241,7 +241,7 @@
             {% for comment in pagination %}
                 <div class="uv-view-comment">
                     <a href="{{ path('user_view', {'login': comment.user.login}) }}">
-                        <img src="{{ path('user_view_image_profil', {'login': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
+                        <img src="{{ path('user_view_image_profil', {'avatar': comment.user.avatar}) }}" class="uv-view-comment-avatar" />
                     </a>
                     <div class="uv-view-comment-author">
                         <a href="{{ path('user_view', {'login': comment.user.login}) }}">

--- a/web/uploads/photos/.htaccess
+++ b/web/uploads/photos/.htaccess
@@ -4,3 +4,29 @@ allow from 127.0.0.1
 allow from 10.0.0.0/8
 allow from 172.16.0.0/12
 allow from 192.168.0.0/16
+
+#Autoriser l'accès aux images des contributeurs
+<Files "galopint.png">
+    Order allow,deny
+    allow from all
+</Files>
+
+<Files "soulierl.jpg">
+    Order allow,deny
+    allow from all
+</Files>
+
+<Files "chabanop.jpg">
+    Order allow,deny
+    allow from all
+</Files>
+
+<Files "prouxale.png">
+    Order allow,deny
+    allow from all
+</Files>
+
+<Files "schultzn.jpg">
+    Order allow,deny
+    allow from all
+</Files>

--- a/web/uploads/photos/.htaccess
+++ b/web/uploads/photos/.htaccess
@@ -1,0 +1,6 @@
+order deny,allow
+deny from all
+allow from 127.0.0.1
+allow from 10.0.0.0/8
+allow from 172.16.0.0/12
+allow from 192.168.0.0/16


### PR DESCRIPTION
Objectif : faire en sorte que seuls les utilisateurs connectés puissent accéder aux images de profil

* Création d'un .htaccess dans web/uploads/photos pour bloquer toutes les requêtes directes, sauf celles provenant d'un réseau privé
* Création d'un controller dans src/Etu/Core/UserBundle/Controller/ProfileController.php nommé `user_view_image_profil`, se référant à la fonction `viewImageProfil` ayant pour route `/images/profil/{login}`. Cette fonction renvoie l'image correspondant au login, ou `default-avatar` si le login n'est pas trouvé. L'accès à la route est conditionné au rôle `ROLE_CORE_PROFIL`, identique à celui nécessaire pour voir le profil d'autrui.
* Modifications dans les templates twig de tous les appels aux assets de uploads/photos (**WORK IN PROGRESS**, j'ai pas fini)

Et j'ai toujours pas pigé comment je pouvais tester facilement et simplement le site etu (y a pas un docker qui traine pour ça qq part ?)