### PR TITLE
RGPD : Add privacy to schedule

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -185,6 +185,6 @@ security:
                 provider: passwords
             remember_me:
                 secret:   '%secret%'
-                lifetime: 31536000 # 1 year in seconds
+                lifetime: 604800 # 1 week in seconds
                 path:     /
-                always_remember_me: true
+                always_remember_me: false

--- a/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
@@ -68,8 +68,8 @@ class PrivateUserController extends ApiController
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
 
-            /** @var $courses Course[] */
-            $courses = $em->createQueryBuilder()
+        /** @var $courses Course[] */
+        $courses = $em->createQueryBuilder()
                 ->select('c.uv, c.day, c.start, c.end, c.week, c.type, c.room')
                 ->from('EtuUserBundle:Course', 'c')
                 ->where('c.deletedAt IS NULL')
@@ -78,7 +78,7 @@ class PrivateUserController extends ApiController
                 ->getQuery()
                 ->getResult();
 
-            return $this->format(['courses' => $courses], 200, [], $request);
+        return $this->format(['courses' => $courses], 200, [], $request);
     }
 
     /**
@@ -105,17 +105,17 @@ class PrivateUserController extends ApiController
         $hours = [];
 
         foreach ($courses as $course) {
-            if ($course->getDay() == Course::DAY_MONDAY) {
+            if (Course::DAY_MONDAY == $course->getDay()) {
                 $days[] = 1;
-            } elseif ($course->getDay() == Course::DAY_TUESDAY) {
+            } elseif (Course::DAY_TUESDAY == $course->getDay()) {
                 $days[] = 2;
-            } elseif ($course->getDay() == Course::DAY_WENESDAY) {
+            } elseif (Course::DAY_WENESDAY == $course->getDay()) {
                 $days[] = 3;
-            } elseif ($course->getDay() == Course::DAY_THURSDAY) {
+            } elseif (Course::DAY_THURSDAY == $course->getDay()) {
                 $days[] = 4;
-            } elseif ($course->getDay() == Course::DAY_FRIDAY) {
+            } elseif (Course::DAY_FRIDAY == $course->getDay()) {
                 $days[] = 5;
-            } elseif ($course->getDay() == Course::DAY_SATHURDAY) {
+            } elseif (Course::DAY_SATHURDAY == $course->getDay()) {
                 $days[] = 6;
             } else {
                 $days[] = 7;

--- a/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
@@ -55,6 +55,34 @@ class PrivateUserController extends ApiController
 
     /**
      * @ApiDoc(
+     *   description = "Courses list of a given user (scope: private), in case of private schedule",
+     *   section = "User - Private data",
+     *   authentication = true,
+     *   authenticationRoles = {"private_user_schedule"},
+     *
+     * @Route("/courses", name="api_private_user_courses")
+     * @Method("GET")
+     */
+    public function coursesAction(Request $request)
+    {
+        /** @var EntityManager $em */
+        $em = $this->getDoctrine()->getManager();
+
+            /** @var $courses Course[] */
+            $courses = $em->createQueryBuilder()
+                ->select('c.uv, c.day, c.start, c.end, c.week, c.type, c.room')
+                ->from('EtuUserBundle:Course', 'c')
+                ->where('c.deletedAt IS NULL')
+                ->andWhere('c.user = :user')
+                ->setParameter('user', $this->getAccessToken($request)->getUser())
+                ->getQuery()
+                ->getResult();
+
+            return $this->format(['courses' => $courses], 200, [], $request);
+    }
+
+    /**
+     * @ApiDoc(
      *   section = "User - Private data",
      *   authentication = true,
      *   authenticationRoles = {"private_user_schedule"},

--- a/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PrivateUserController.php
@@ -59,9 +59,11 @@ class PrivateUserController extends ApiController
      *   section = "User - Private data",
      *   authentication = true,
      *   authenticationRoles = {"private_user_schedule"},
+     * )
      *
-     * @Route("/courses", name="api_private_user_courses")
+     * @Route("/courses", name="api_private_user_courses", options={"expose"=true})
      * @Method("GET")
+     * @Scope("private_user_schedule")
      */
     public function coursesAction(Request $request)
     {

--- a/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
@@ -183,17 +183,24 @@ class PublicUsersListController extends ApiController
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
 
-        /** @var $courses Course[] */
-        $courses = $em->createQueryBuilder()
-            ->select('c.uv, c.day, c.start, c.end, c.week, c.type, c.room')
-            ->from('EtuUserBundle:Course', 'c')
-            ->where('c.deletedAt IS NULL')
-            ->andWhere('c.user = :user')
-            ->setParameter('user', $user)
-            ->getQuery()
-            ->getResult();
+        if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC)
+        {
+            /** @var $courses Course[] */
+            $courses = $em->createQueryBuilder()
+                ->select('c.uv, c.day, c.start, c.end, c.week, c.type, c.room')
+                ->from('EtuUserBundle:Course', 'c')
+                ->where('c.deletedAt IS NULL')
+                ->andWhere('c.user = :user')
+                ->setParameter('user', $user)
+                ->getQuery()
+                ->getResult();
 
-        return $this->format(['courses' => $courses], 200, [], $request);
+            return $this->format(['courses' => $courses], 200, [], $request);
+        }
+        else
+        {
+            return $this->format(['courses' => []], 200, [], $request);
+        }
     }
 
     /**

--- a/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
+++ b/src/Etu/Core/UserBundle/Api/Resource/PublicUsersListController.php
@@ -183,8 +183,7 @@ class PublicUsersListController extends ApiController
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
 
-        if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC)
-        {
+        if ($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC) {
             /** @var $courses Course[] */
             $courses = $em->createQueryBuilder()
                 ->select('c.uv, c.day, c.start, c.end, c.week, c.type, c.room')
@@ -197,10 +196,8 @@ class PublicUsersListController extends ApiController
 
             return $this->format(['courses' => $courses], 200, [], $request);
         }
-        else
-        {
-            return $this->format(['courses' => []], 200, [], $request);
-        }
+
+        return $this->format(['courses' => []], 200, [], $request);
     }
 
     /**

--- a/src/Etu/Core/UserBundle/Api/Transformer/UserPrivateTransformer.php
+++ b/src/Etu/Core/UserBundle/Api/Transformer/UserPrivateTransformer.php
@@ -72,6 +72,7 @@ class UserPrivateTransformer extends AbstractTransformer
             'isStudent' => $user->getIsStudent(),
             'bdeMember' => $user->isBdeMember(),
             'bdeMembershipEnd' => $user->getBdeMembershipEnd(),
+            'isSchedulePublic' => User::PRIVACY_PUBLIC === $user->getSchedulePrivacy(),
         ];
     }
 

--- a/src/Etu/Core/UserBundle/Api/Transformer/UserTransformer.php
+++ b/src/Etu/Core/UserBundle/Api/Transformer/UserTransformer.php
@@ -74,6 +74,7 @@ class UserTransformer extends AbstractTransformer
             'isStudent' => $user->getIsStudent(),
             'bdeMember' => $user->isBdeMember(),
             'bdeMembershipEnd' => $user->getBdeMembershipEnd(),
+            'isSchedulePublic' => User::PRIVACY_PUBLIC === $user->getSchedulePrivacy(),
         ];
     }
 

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -475,8 +475,7 @@ class ProfileController extends Controller
 
         /** @var $courses Course[] */
         $courses = [];
-        if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
-        {
+        if ($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent()) {
             $courses = $em->getRepository('EtuUserBundle:Course')->findByUser($user);
         }
 

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -192,6 +192,7 @@ class ProfileController extends Controller
                 ], ])
             ->add('personnalMail', EmailType::class, ['required' => false, 'label' => 'user.profile.profileEdit.personnalMail'])
             ->add('personnalMailPrivacy', ChoiceType::class, $privacyChoice)
+            ->add('schedulePrivacy', ChoiceType::class, $privacyChoice)
             ->add('website', null, ['required' => false, 'label' => 'user.profile.profileEdit.website'])
             ->add('facebook', null, ['required' => false, 'label' => 'user.profile.profileEdit.facebook'])
             ->add('twitter', null, ['required' => false, 'label' => 'user.profile.profileEdit.twitter'])
@@ -473,7 +474,11 @@ class ProfileController extends Controller
         }
 
         /** @var $courses Course[] */
-        $courses = $em->getRepository('EtuUserBundle:Course')->findByUser($user);
+        $courses = [];
+        if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
+        {
+            $courses = $em->getRepository('EtuUserBundle:Course')->findByUser($user);
+        }
 
         // Builder to create the schedule
         $builder = new ScheduleBuilder();

--- a/src/Etu/Core/UserBundle/Controller/ProfileController.php
+++ b/src/Etu/Core/UserBundle/Controller/ProfileController.php
@@ -158,7 +158,8 @@ class ProfileController extends Controller
             'required' => false,
             'label' => 'user.profile.profileEdit.privacy',
         ];
-
+        $privacyChoiceSchedule = $privacyChoice;
+        $privacyChoiceSchedule['label'] = 'user.profile.profile.schedule';
         $form = $this->createFormBuilder($user)
             ->add('phoneNumber', null, ['required' => false, 'label' => 'user.profile.profileEdit.phoneNumber'])
             ->add('phoneNumberPrivacy', ChoiceType::class, $privacyChoice)
@@ -192,7 +193,7 @@ class ProfileController extends Controller
                 ], ])
             ->add('personnalMail', EmailType::class, ['required' => false, 'label' => 'user.profile.profileEdit.personnalMail'])
             ->add('personnalMailPrivacy', ChoiceType::class, $privacyChoice)
-            ->add('schedulePrivacy', ChoiceType::class, $privacyChoice)
+            ->add('schedulePrivacy', ChoiceType::class, $privacyChoiceSchedule)
             ->add('website', null, ['required' => false, 'label' => 'user.profile.profileEdit.website'])
             ->add('facebook', null, ['required' => false, 'label' => 'user.profile.profileEdit.facebook'])
             ->add('twitter', null, ['required' => false, 'label' => 'user.profile.profileEdit.twitter'])

--- a/src/Etu/Core/UserBundle/Controller/ScheduleController.php
+++ b/src/Etu/Core/UserBundle/Controller/ScheduleController.php
@@ -73,8 +73,7 @@ class ScheduleController extends Controller
         $users = [];
         $studentsPublicSchedule = [];
         foreach ($students as $student) {
-            if($student->getUser()->getSchedulePrivacy() === $student->getUser()::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
-            {
+            if ($student->getUser()->getSchedulePrivacy() === $student->getUser()::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent()) {
                 $users[] = $student->getUser()->getLogin();
                 $studentsPublicSchedule[] = $student;
             }
@@ -136,11 +135,11 @@ class ScheduleController extends Controller
         $semesterEnd = SemesterManager::current()->getEnd()->format('Ymd\THis');
 
         foreach ($courses as $course) {
-            if ($course->getUv() == 'SPJE') {
+            if ('SPJE' == $course->getUv()) {
                 continue;
             }
 
-            if ($course->getDay() == Course::DAY_SATHURDAY) {
+            if (Course::DAY_SATHURDAY == $course->getDay()) {
                 $day = 'saturday';
             } else {
                 $day = $course->getDay();
@@ -156,7 +155,7 @@ class ScheduleController extends Controller
             $time = explode(':', $course->getEnd());
             $end->setTime($time[0], $time[1]);
 
-            $summary = ($course->getWeek() != 'T') ? $course->getUv().' ('.$course->getWeek().')' : $course->getUv();
+            $summary = ('T' != $course->getWeek()) ? $course->getUv().' ('.$course->getWeek().')' : $course->getUv();
 
             $vcalendar->add('VEVENT', [
                 'SUMMARY' => $summary.' - '.$course->getType(),
@@ -204,8 +203,8 @@ class ScheduleController extends Controller
             Course::DAY_THURSDAY, Course::DAY_FRIDAY, Course::DAY_SATHURDAY,
         ];
 
-        if (!in_array($day, $days)) {
-            if (date('w') == 0) { // Sunday
+        if (!\in_array($day, $days)) {
+            if (0 == date('w')) { // Sunday
                 $day = Course::DAY_MONDAY;
             } else {
                 $day = $days[date('w') - 1];

--- a/src/Etu/Core/UserBundle/Controller/ScheduleController.php
+++ b/src/Etu/Core/UserBundle/Controller/ScheduleController.php
@@ -71,15 +71,20 @@ class ScheduleController extends Controller
             ->getResult();
 
         $users = [];
+        $studentsPublicSchedule = [];
         foreach ($students as $student) {
-            $users[] = $student->getUser()->getLogin();
+            if($student->getUser()->getSchedulePrivacy() === $student->getUser()::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
+            {
+                $users[] = $student->getUser()->getLogin();
+                $studentsPublicSchedule[] = $student;
+            }
         }
         $cumulLogins = implode(':', $users);
 
         return [
             'cumulLogins' => $cumulLogins,
             'course' => $course,
-            'students' => $students,
+            'students' => $studentsPublicSchedule,
         ];
     }
 

--- a/src/Etu/Core/UserBundle/Entity/User.php
+++ b/src/Etu/Core/UserBundle/Entity/User.php
@@ -619,6 +619,14 @@ class User implements UserInterface, EquatableInterface, \Serializable
      */
     protected $privateToken;
 
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @Assert\NotBlank()
+     */
+    protected $schedulePrivacy;
+
     /*
      * Methods
      */
@@ -641,6 +649,7 @@ class User implements UserInterface, EquatableInterface, \Serializable
         $this->cityPrivacy = self::PRIVACY_PUBLIC;
         $this->countryPrivacy = self::PRIVACY_PUBLIC;
         $this->birthdayPrivacy = self::PRIVACY_PUBLIC;
+        $this->schedulePrivacy = self::PRIVACY_PUBLIC;
         $this->birthdayDisplayOnlyAge = false;
         $this->personnalMailPrivacy = self::PRIVACY_PUBLIC;
         $this->options = new UserOptionsCollection();
@@ -2713,6 +2722,23 @@ class User implements UserInterface, EquatableInterface, \Serializable
     {
         $this->privateToken = Uuid::getFactory()->uuid4();
 
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSchedulePrivacy() : int
+    {
+        return $this->schedulePrivacy;
+    }
+
+    /**
+     * @param int $schedulePrivacy
+     */
+    public function setSchedulePrivacy(int $schedulePrivacy)
+    {
+        $this->schedulePrivacy = $schedulePrivacy;
         return $this;
     }
 }

--- a/src/Etu/Core/UserBundle/Entity/User.php
+++ b/src/Etu/Core/UserBundle/Entity/User.php
@@ -2725,20 +2725,15 @@ class User implements UserInterface, EquatableInterface, \Serializable
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getSchedulePrivacy() : int
+    public function getSchedulePrivacy(): int
     {
         return $this->schedulePrivacy;
     }
 
-    /**
-     * @param int $schedulePrivacy
-     */
     public function setSchedulePrivacy(int $schedulePrivacy)
     {
         $this->schedulePrivacy = $schedulePrivacy;
+
         return $this;
     }
 }

--- a/src/Etu/Core/UserBundle/Resources/translations/messages.de.yml
+++ b/src/Etu/Core/UserBundle/Resources/translations/messages.de.yml
@@ -256,6 +256,7 @@ user:
             address: Adresse
             birthday: Geburtsdatum
             age: %age% Jahre
+            schedule: Programme
             trombi: Jahrbuch
             surname: Spitzname
             jadis: Früher

--- a/src/Etu/Core/UserBundle/Resources/translations/messages.en.yml
+++ b/src/Etu/Core/UserBundle/Resources/translations/messages.en.yml
@@ -165,6 +165,7 @@ user:
             address: address
             birthday: Date of birth
             age: "%age% years old"
+            schedule: Schedule
             trombi: Group photo
             apps: Applications you allowed to access your informations
             surname: Nickname

--- a/src/Etu/Core/UserBundle/Resources/translations/messages.fr.yml
+++ b/src/Etu/Core/UserBundle/Resources/translations/messages.fr.yml
@@ -305,6 +305,7 @@ user:
             address: Adresse
             birthday: Date de naissance
             age: "%age% ans"
+            schedule: Emploi du temps
             trombi: Trombinoscope
             surname: Surnom
             jadis: Jadis

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profile.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profile.html.twig
@@ -210,6 +210,20 @@
                         <div class="clear"></div>
                     </div>
 
+                    <div class="subblock">
+                        <div class="profile-infos-label hidden-for-phones">
+                            {{ 'user.profile.profile.schedule'|trans }}
+                        </div>
+                        <div class="profile-infos-value">
+                            {% if is_private(app.user.schedulePrivacy) %}
+                                <i class="icon-lock tip" title="{{ 'user.privacy.private'|trans }}"></i>
+                            {% else %}
+                                <i class="icon-globe tip" title="{{ 'user.privacy.public'|trans }}"></i>
+                            {% endif %}
+                        </div>
+                        <div class="clear"></div>
+                    </div>
+
                     <p class="profile-block-action">
                         <a href="{{ path('user_profile_edit') }}" class="btn">
                             {{ 'user.profile.profile.edit'|trans }}

--- a/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
+++ b/src/Etu/Core/UserBundle/Resources/views/Profile/profileEdit.html.twig
@@ -96,6 +96,11 @@
                     {{ form_row(form.daymail) }}
                 </div>
             </div>
+        <div class="row-fluid">
+            <div class="span6">
+                {{ form_row(form.schedulePrivacy) }}
+            </div>
+        </div>
             <hr/>
 
             <div class="row-fluid">

--- a/src/Etu/Module/CumulBundle/Controller/MainController.php
+++ b/src/Etu/Module/CumulBundle/Controller/MainController.php
@@ -66,7 +66,10 @@ class MainController extends Controller
         $usersIds = [];
 
         foreach ($users as $user) {
-            $usersIds[] = $user->getId();
+            if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
+            {
+                $usersIds[] = $user->getId();
+            }
         }
 
         /** @var $courses Course[] */

--- a/src/Etu/Module/CumulBundle/Controller/MainController.php
+++ b/src/Etu/Module/CumulBundle/Controller/MainController.php
@@ -44,7 +44,7 @@ class MainController extends Controller
             ->getQuery()
             ->getResult();
 
-        if (count($logins) != count($users)) {
+        if (\count($logins) != \count($users)) {
             $found = [];
 
             foreach ($users as $user) {
@@ -55,7 +55,7 @@ class MainController extends Controller
                 'type' => 'error',
                 'message' => $this->get('translator')->transChoice(
                         'cumul.main.errors.invalid_logins',
-                        count(array_diff($logins, $found)),
+                        \count(array_diff($logins, $found)),
                         ['%items%' => implode('", "', array_diff($logins, $found))]
                     ),
             ]);
@@ -66,8 +66,7 @@ class MainController extends Controller
         $usersIds = [];
 
         foreach ($users as $user) {
-            if($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent())
-            {
+            if ($user->getSchedulePrivacy() === $user::PRIVACY_PUBLIC || !$this->getUser()->getIsStudent()) {
                 $usersIds[] = $user->getId();
             }
         }
@@ -188,8 +187,8 @@ class MainController extends Controller
             'comparison' => $availabilities[0],
             'invertComparison' => $availabilities[1],
             'users' => $users,
-            'countUsers' => count($users),
-            'colSize' => round(14 / count($users), 2),
+            'countUsers' => \count($users),
+            'colSize' => round(14 / \count($users), 2),
             'logins' => json_encode($logins),
             'addBranchs' => $addBranchs,
             'removeUrlsLogins' => $removeUrlsLogins,
@@ -215,7 +214,7 @@ class MainController extends Controller
         /** @var EntityManager $em */
         $em = $this->getDoctrine()->getManager();
 
-        if ($type == 'file') {
+        if ('file' == $type) {
             /*
              * File import
              */
@@ -226,14 +225,14 @@ class MainController extends Controller
             // Data type
             $dataType = $post->get('import-data-type');
 
-            if (!in_array($dataType, ['fullName', 'login', 'studentId'])) {
+            if (!\in_array($dataType, ['fullName', 'login', 'studentId'])) {
                 $dataType = 'fullName';
             }
 
             // Separator
             $separator = "\n";
 
-            if ($post->get('separator-textarea') != 'new-line' && mb_strlen($post->get('separator-char')) >= 1) {
+            if ('new-line' != $post->get('separator-textarea') && mb_strlen($post->get('separator-char')) >= 1) {
                 $separator = $post->get('separator-char');
             }
 
@@ -249,14 +248,14 @@ class MainController extends Controller
             // Data type
             $dataType = $post->get('import-data-type');
 
-            if (!in_array($dataType, ['fullName', 'login', 'studentId'])) {
+            if (!\in_array($dataType, ['fullName', 'login', 'studentId'])) {
                 $dataType = 'fullName';
             }
 
             // Separator
             $separator = "\n";
 
-            if ($post->get('separator-textarea') != 'new-line' && mb_strlen($post->get('separator-char')) >= 1) {
+            if ('new-line' != $post->get('separator-textarea') && mb_strlen($post->get('separator-char')) >= 1) {
                 $separator = $post->get('separator-char');
             }
 
@@ -272,13 +271,13 @@ class MainController extends Controller
             ->getQuery()
             ->getResult();
 
-        if (count($dataItems) > count($users)) {
+        if (\count($dataItems) > \count($users)) {
             $dbItems = [];
 
             foreach ($users as $user) {
-                if ($dataType == 'fullName') {
+                if ('fullName' == $dataType) {
                     $dbItems[] = $user->getFullName();
-                } elseif ($dataType == 'studentId') {
+                } elseif ('studentId' == $dataType) {
                     $dbItems[] = $user->getStudentId();
                 } else {
                     $dbItems[] = $user->getLogin();
@@ -287,9 +286,9 @@ class MainController extends Controller
 
             $errorType = 'cumul.main.errors.invalid_logins';
 
-            if ($dataType == 'fullName') {
+            if ('fullName' == $dataType) {
                 $errorType = 'cumul.main.errors.invalid_names';
-            } elseif ($dataType == 'studentId') {
+            } elseif ('studentId' == $dataType) {
                 $errorType = 'cumul.main.errors.invalid_ids';
             }
 
@@ -297,7 +296,7 @@ class MainController extends Controller
                 'type' => 'error',
                 'message' => $this->get('translator')->transChoice(
                         $errorType,
-                        count(array_diff($dataItems, $dbItems)),
+                        \count(array_diff($dataItems, $dbItems)),
                         ['%items%' => implode('", "', array_diff($dataItems, $dbItems))]
                     ),
             ]);

--- a/src/Etu/Module/WikiBundle/Controller/MainController.php
+++ b/src/Etu/Module/WikiBundle/Controller/MainController.php
@@ -29,7 +29,7 @@ class MainController extends Controller
     {
         // Find organization
         $em = $this->getDoctrine()->getManager();
-        if ($organization && $organization != 'general') {
+        if ($organization && 'general' != $organization) {
             $organization = $em->getRepository('EtuUserBundle:Organization')
                 ->findOneBy(['login' => $request->get('organization')]);
             if (!$organization) {
@@ -47,7 +47,7 @@ class MainController extends Controller
         ], ['createdAt' => 'DESC']);
 
         // If not found
-        if (count($page) != 1) {
+        if (1 != \count($page)) {
             throw $this->createNotFoundException('Wiki page not found');
         }
 
@@ -114,7 +114,7 @@ class MainController extends Controller
     {
         // Find organization
         $em = $this->getDoctrine()->getManager();
-        if ($organization && $organization != 'general') {
+        if ($organization && 'general' != $organization) {
             $organization = $em->getRepository('EtuUserBundle:Organization')
                 ->findOneBy(['login' => $request->get('organization')]);
             if (!$organization) {
@@ -139,14 +139,14 @@ class MainController extends Controller
                 return $this->createAccessDeniedResponse();
             }
             // Check if subslug exist
-            if (!empty($slug) && count($page) != 1) {
+            if (!empty($slug) && 1 != \count($page)) {
                 return $this->createAccessDeniedResponse();
             }
             $page = new WikiPage();
             $page->setReadRight(WikiPage::RIGHT['STUDENT']);
             $page->setEditRight(WikiPage::RIGHT['STUDENT']);
         } else {
-            if (count($page) != 1) {
+            if (1 != \count($page)) {
                 throw $this->createNotFoundException('Wiki page not found');
             } elseif (!$rights->canEdit($page)) {
                 return $this->createAccessDeniedResponse();
@@ -183,7 +183,7 @@ class MainController extends Controller
             foreach ($result as $key => $value) {
                 if ($rights->has($value['readRight'], $organization)) {
                     $pagelist[$key] = $value['title'];
-                    if (mb_strpos($key, '/') !== false) {
+                    if (false !== mb_strpos($key, '/')) {
                         $pagelist[$key] = '↳'.$pagelist[$key];
                     }
                 }
@@ -217,7 +217,7 @@ class MainController extends Controller
         }
         $form = $form->add('readRight', ChoiceType::class, ['choices' => $choices, 'required' => true, 'label' => 'wiki.main.edit.readRight']);
         unset($choices['wiki.main.right.'.WikiPage::RIGHT['ALL']]);
-        if (count($choices) > 1) {
+        if (\count($choices) > 1) {
             $form = $form->add('editRight', ChoiceType::class, ['choices' => $choices, 'required' => true, 'label' => 'wiki.main.edit.editRight']);
         }
 
@@ -299,7 +299,7 @@ class MainController extends Controller
     {
         // Find organization
         $em = $this->getDoctrine()->getManager();
-        if ($organization && $organization != 'general') {
+        if ($organization && 'general' != $organization) {
             $organization = $em->getRepository('EtuUserBundle:Organization')
                 ->findOneBy(['login' => $request->get('organization')]);
             if (!$organization) {
@@ -353,7 +353,7 @@ class MainController extends Controller
      * @Route("/wiki/linklist/{organization}", name="wiki_linklist", options={"expose"=true})
      * @Template()
      *
-     * @param null|mixed $organization
+     * @param mixed|null $organization
      */
     public function editorAction(Request $request, $organization = null)
     {
@@ -402,7 +402,7 @@ class MainController extends Controller
     /**
      * Called by rich text editor to show a list of available links.
      *
-     * @Route("/wiki/list", name="wiki_list")
+     * @Route("/wiki", name="wiki_list")
      * @Template()
      */
     public function wikilistAction(Request $request)
@@ -440,7 +440,7 @@ class MainController extends Controller
     {
         // Find organization
         $em = $this->getDoctrine()->getManager();
-        if ($organization && $organization != 'general') {
+        if ($organization && 'general' != $organization) {
             $organization = $em->getRepository('EtuUserBundle:Organization')
                 ->findOneBy(['login' => $request->get('organization')]);
             if (!$organization) {
@@ -459,7 +459,7 @@ class MainController extends Controller
 
         // If not found
         $rights = $this->get('etu.wiki.permissions_checker');
-        if (count($page) != 1) {
+        if (1 != \count($page)) {
             throw $this->createNotFoundException('Wiki page not found');
         } elseif (!$rights->canDelete($page)) {
             return $this->createAccessDeniedResponse();
@@ -502,7 +502,7 @@ class MainController extends Controller
         }
 
         // Submit yes
-        if ($request->query->get('confirm') === 'yes' && !$childrenPages) {
+        if ('yes' === $request->query->get('confirm') && !$childrenPages) {
             // Force insertion
             $page = clone $page;
 
@@ -549,7 +549,7 @@ class MainController extends Controller
     {
         // Find organization
         $em = $this->getDoctrine()->getManager();
-        if ($organization && $organization != 'general') {
+        if ($organization && 'general' != $organization) {
             $organization = $em->getRepository('EtuUserBundle:Organization')
                 ->findOneBy(['login' => $request->get('organization')]);
             if (!$organization) {
@@ -568,7 +568,7 @@ class MainController extends Controller
 
         // If not found
         $rights = $this->get('etu.wiki.permissions_checker');
-        if (count($page) != 1) {
+        if (1 != \count($page)) {
             throw $this->createNotFoundException('Wiki page not found');
         } elseif (!$rights->canMove($page)) {
             return $this->createAccessDeniedResponse();
@@ -596,7 +596,7 @@ class MainController extends Controller
         $pagelist = [];
         foreach ($result as $key => $value) {
             if ($rights->has($value['readRight'], $organization)
-                && mb_strpos($key, $page->getSlug()) !== 0) {
+                && 0 !== mb_strpos($key, $page->getSlug())) {
                 $pagelist[$key] = $key.'/';
             }
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37900449/88433188-e9bb2f00-cdfd-11ea-91d5-afce96558963.png)


# Objectif

* **Permettre à un utilisateur de rendre privé son emploi du temps.**
* **Comportement attendu si l'emploi du temps est privé :** l'étudiant n'a aucun cours (emploi du temps vide, comme pour les stages par exemple)
* **Les enseignants/personnels auront toujours accès à l'emploi du temps**, car ils y ont déjà accès via les outils de l'UTT, donc inutile des les bloquer ici

# Fait

## Core
* Ajout d'une propriété `schedulePrivacy` dans la classe User, fonctionnant comme les autres propriétés relatives à la vie privée
* Par défaut, l'emploi du temps est public

## Site
* Modification de l'affichage de l'emploi du temps pour renvoyer un emploi du temps vide le cas échéant
* Ajout d'un sélecteur pour que l'utilisateur choisisse la confidentialité de son emploi du temps dans les paramètres de son profil
* Affichage de la confidentialité de l'emploi du temps sur la page d'accueil de son profil personnel
* Dans le cumul, l'utilisateur ayant un emploi du temps privé sera considéré comme tout le temps disponible

## API
* Ajout dans les données publiques et privées de l'utilisateur d'un booléen `ìsSchedulePublic`, qui sera vrai si l'emploi du temps est public ou faux sinon
* La route publique `/api/public/users/{login}/courses` renverra une liste de cours vide si l'emploi du temps de l'utilisateur est privé
* J'ai créé une nouvelle route `/api/private/user/courses`, accessible avec le scope `private_user_schedule` qui renverra la liste des cours

# Testé

Pas grand chose, car je n'ai dans ma base ni UEs, ni créneaux et je n'arrive toujours pas à faire fonctionner mon API.