### PR TITLE
Conservation des données exif dans les images de la gallerie Argentique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Actuelle
 * Ajout des personnels UTT dans le trombi et de filtre sur le statut étudiant / enseignant
 * Les photos officielles des utilisateurs sont désormais récupérées via un script externe [utt-profile-pictures](https://github.com/ungdev/utt-profile-pictures) (développé grâce à la lib python [pyutttils](http://github.com/larueli/pyutttils/)) puis placées dans un dossier et récupérées par le site etu.
 * Mise à jour de la liste des UEs
+* Migration vers Imagick, conservation des métadonnées des images, optimisation du traitement des images (#273, merci @Alabate)
 * La commande etu:ue:import synchronise désormais les UEs de la DB avec le CSV (pas d'ajout brut). Les UEs pas dans le CSV sont marquées dépréciées.
 * Les étudiants salariés de l'UTT sont également considérés comme étudiants et non plus juste salariés (accès aux commentaires, ...)
 

--- a/src/Etu/Module/ArgentiqueBundle/Command/WarmupCacheCommand.php
+++ b/src/Etu/Module/ArgentiqueBundle/Command/WarmupCacheCommand.php
@@ -8,6 +8,7 @@ use Etu\Module\ArgentiqueBundle\EtuModuleArgentiqueBundle;
 use Etu\Module\ArgentiqueBundle\Glide\ImageBuilder;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -20,7 +21,13 @@ class WarmupCacheCommand extends ContainerAwareCommand
     {
         $this
             ->setName('etu:argentique:warmup')
-            ->setDescription('Warm-up the argentique galery cache.');
+            ->setDescription('Warm-up the argentique galery cache.')
+            ->addOption(
+                'force-rebuild',
+                'f',
+                InputOption::VALUE_NONE,
+                'Force rebuild of already created cache for all images'
+            );
     }
 
     /**
@@ -44,6 +51,11 @@ class WarmupCacheCommand extends ContainerAwareCommand
 
             // Keep only relative path
             $image = mb_substr($image, mb_strlen($root));
+
+            // Clear cache if rebuild is requested
+            if ($input->getOption('force-rebuild')) {
+                ImageBuilder::deleteCache($image);
+            }
 
             // Generate each type of image
             ImageBuilder::createImageResponse($image, '');

--- a/src/Etu/Module/ArgentiqueBundle/Glide/CustomServerFactory.php
+++ b/src/Etu/Module/ArgentiqueBundle/Glide/CustomServerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Etu\Module\ArgentiqueBundle\Glide;
+
+use League\Glide\ServerFactory;
+
+/**
+ * Customize the original Glide ServerFactory to add our custom image manipulator.
+ */
+class CustomServerFactory extends ServerFactory
+{
+    /**
+     * Get image manipulators.
+     *
+     * @return array image manipulators
+     */
+    public function getManipulators()
+    {
+        return [
+            new CustomizedEncode(),
+        ];
+    }
+}

--- a/src/Etu/Module/ArgentiqueBundle/Glide/ImageBuilder.php
+++ b/src/Etu/Module/ArgentiqueBundle/Glide/ImageBuilder.php
@@ -4,7 +4,6 @@ namespace Etu\Module\ArgentiqueBundle\Glide;
 
 use Etu\Module\ArgentiqueBundle\EtuModuleArgentiqueBundle;
 use League\Glide\Responses\SymfonyResponseFactory;
-use League\Glide\ServerFactory;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -22,11 +21,12 @@ class ImageBuilder
             throw new NotFoundHttpException('Picture not found');
         }
 
-        $glide = ServerFactory::create(
+        $glide = CustomServerFactory::create(
             [
                 'source' => $root,
                 'cache' => $cache_root,
                 'response' => new SymfonyResponseFactory(),
+                'driver' => 'imagick',
             ]
         );
 

--- a/src/Etu/Module/ArgentiqueBundle/Glide/ImageBuilder.php
+++ b/src/Etu/Module/ArgentiqueBundle/Glide/ImageBuilder.php
@@ -11,7 +11,14 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class ImageBuilder
 {
-    public static function createImageResponse($path, $mode = '')
+    /**
+     * Create glide image generator server.
+     *
+     * @param mixed $path
+     *
+     * @return League\Glide\Server the glide server
+     */
+    protected static function getGlideServer($path)
     {
         /** @var string $root */
         $root = EtuModuleArgentiqueBundle::getPhotosRoot();
@@ -21,7 +28,7 @@ class ImageBuilder
             throw new NotFoundHttpException('Picture not found');
         }
 
-        $glide = CustomServerFactory::create(
+        return CustomServerFactory::create(
             [
                 'source' => $root,
                 'cache' => $cache_root,
@@ -29,6 +36,20 @@ class ImageBuilder
                 'driver' => 'imagick',
             ]
         );
+    }
+
+    /**
+     * Create an image response for the given mode. Image will be pulled from
+     * cache or created if needed.
+     *
+     * @param string $path Image path
+     * @param string $mode Generation mode between 'thumbnail', 'slideshow' or empty
+     *
+     * @return Reponse The image reponse
+     */
+    public static function createImageResponse($path, $mode = '')
+    {
+        $glideServer = ImageBuilder::getGlideServer($path);
 
         switch ($mode) {
             case 'thumbnail':
@@ -41,6 +62,17 @@ class ImageBuilder
                 $param = ['q' => 90, 'fm' => 'pjpg'];
         }
 
-        return $glide->getImageResponse($path, $param);
+        return $glideServer->getImageResponse($path, $param);
+    }
+
+    /**
+     * Clear all caches (all modes) for the given image path.
+     *
+     * @param $path Image path
+     */
+    public static function deleteCache($path)
+    {
+        $glideServer = ImageBuilder::getGlideServer($path);
+        $glideServer->deleteCache($path);
     }
 }

--- a/src/Etu/Module/ArgentiqueBundle/Glide/Manipulators/CustomEncode.php
+++ b/src/Etu/Module/ArgentiqueBundle/Glide/Manipulators/CustomEncode.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Etu\Module\ArgentiqueBundle\Glide\Manipulators;
+
+use Intervention\Image\Image;
+use League\Glide\Manipulators\Encode;
+
+/**
+ * Customize the original Glide CustomEncode to avoid re-creating the image
+ * when converting jpg to jpg to avoid loosing exif informations (exif
+ * informations are only conserved when using imagick).
+ *
+ * @property string $fm
+ * @property string $q
+ */
+class CustomEncode extends Encode
+{
+    /**
+     * Perform output image manipulation.
+     *
+     * @param Image $image the source image
+     *
+     * @return Image the manipulated image
+     */
+    public function run(Image $image)
+    {
+        $format = $this->getFormat($image);
+        $quality = $this->getQuality();
+
+        // Apply a white background if the source format ($image->mime()) support
+        // transparency, while the target format (`$format`)
+        // All $allowed format except jpg/pjpg supports transparency
+        if ('image/jpeg' != $image->mime() && in_array($format, ['jpg', 'pjpg'], true)) {
+            $image = $image->getDriver()
+                           ->newImage($image->width(), $image->height(), '#fff')
+                           ->insert($image, 'top-left', 0, 0);
+        }
+
+        if ('pjpg' === $format) {
+            $image->interlace();
+            $format = 'jpg';
+        }
+
+        return $image->encode($format, $quality);
+    }
+}


### PR DESCRIPTION
### Objectif
Actuellement le système de génération du cache (glide) des images argentique fait qu'on perd toutes les données exif sur les photos affichées. Y compris la date de prise de photo, donc quand les photos sont téléchargées, elles sont classées n'importe comment par les logiciels de galerie (typiquement sur smartphone). Et il n'y a actuellement aucun moyen de récupérer cette information du point de vue de l'utilisateur final.

### Etape 1 : Passer à Imagick
La première chose à faire c'est de passer le driver de Glide depuis `gd` (valeur par défaut) à `imagick`. `gd` est en effet incapable de sauvegarder une image avec des données exif, donc peu importe ce qu'on fait il les effacera. Il est possible qu'on ait une différence de performance, mais je ne l'ai pas mesuré. Cependant on reste sur une implé compilées donc ça devrait pas être trop violent non plus je pense.

Les deux driver sont présent dans l'image docker `larueli/php-base-image`, donc si c'est bien celle là qui est utilisé sur la prod, il n'y aura pas de soucis.

### Etape 2 : Eviter de re-créer l'image quand ce n'est pas nécéssaire
Je viens ensuite hériter le `Manipulator` `Encode` parce qu'il vient re-créer l'image de zero pour ajouter un fond blanc alors que ça n'a d'interet que lorsque le format d'image source support le transparent. Ce qui n'est pas le cas la plupart du temps pour nous (les photos sont généralement en jpg qui ne supporte pas la transparence). Le fait de re-créer l'image nous faisait perdre les données exif en plus d'avoir probablement un cout en mémoire supplémentaire pour rien.

Une fois la classe `Manipulator` héritée, on fait hérite `ServerFactory` pour nous permettre d'utiliser notre nouveau `Manipulator`. Au passage j'enlève tous les autres `Manipulator`s dont on ne se sert pas.

Les nouvelles images de cache créées auront maintenant leurs données exif conservées. Cependant ça ne sera pas le cas sur les anciennes images pour lesquels nous avons déjà un cache.

### Etape 3 :  Ajouter une option sur le warmup de cache pour supprimer les anciennes images
Il faudra donc lancer la commande suivante en prod une fois déployé
```
 ./bin/console etu:argentique:warmup -f
```

### Notes
J'aurais bien aimé ajouter quelques tests, mais de ce que je vois ils sont pas executés et phpunit semble pas installé ? Donc j'ai même pas pu lancer les existants. Si les tests sont actuellement run et que j'ai pas vu, dites moi, j'en rajouterais.